### PR TITLE
Init bundle

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Why?
+<!-- Explain why you've done it like this -->
+
+## How?
+<!-- Explain how you've done it -->
+
+## Todo
+<!-- List things you'll have to do before merging/deploying -->
+* [x] TODO 1
+* [ ] TODO 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+app/bootstrap.php.cache
+app/cache/*
+app/logs/*
+build/
+vendor/
+bin/
+composer.lock
+.php_cs.cache
+
+.phpunit
+phpunit.xml

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,10 @@
+<?php
+
+$config = new M6Web\CS\Config\Php71;
+
+$config->getFinder()
+    ->in([
+        __DIR__
+    ]);
+
+return $config;

--- a/Client/ClientInterface.php
+++ b/Client/ClientInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Client;
+
+interface ClientInterface
+{
+    /**
+     * Define a valid server configuration at instantiation
+     */
+    public function __construct(ServerInterface $server);
+
+    /**
+     * Send metrics data to the configured server
+     *
+     * @param array $lines array of string lines to send
+     */
+    public function sendLines(array $lines): void;
+}

--- a/Client/Server.php
+++ b/Client/Server.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Client;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\ServerException;
+
+class Server implements ServerInterface
+{
+    /** @var string */
+    private $name;
+
+    /** @var mixed string format udp://.+ */
+    private $address;
+
+    /** @var mixed int port number */
+    private $port;
+
+    /**
+     * Server constructor.
+     *
+     * @param string $serverName
+     * @param array  $serverConfig
+     *
+     * @throws ServerException
+     */
+    public function __construct(string $serverName, array $serverConfig)
+    {
+        if ($this->checkServersConfigurations($serverName, $serverConfig)) {
+            $this->name = $serverName;
+            $this->address = $serverConfig['address'];
+            $this->port = intval($serverConfig['port']);
+        }
+    }
+
+    /**
+     * Init the servers defined in the app configuration
+     *
+     * @param string $serverName
+     * @param array  $serverConfig
+     *
+     * @return bool
+     *
+     * @throws ServerException
+     */
+    protected function checkServersConfigurations(string $serverName, array $serverConfig): bool
+    {
+        if (empty($serverConfig)) {
+            throw new ServerException('No servers have been configured');
+        }
+
+        if (!isset($serverConfig['address']) || !isset($serverConfig['port'])) {
+            throw new ServerException($serverName.' : no address or port in the configuration');
+        }
+        if (strpos($serverConfig['address'], 'udp://') !== 0) {
+            throw new ServerException($serverName.' : address should begin with udp://');
+        }
+
+        return true;
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+}

--- a/Client/ServerInterface.php
+++ b/Client/ServerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Client;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\ServerException;
+
+interface ServerInterface
+{
+    /**
+     * @throws ServerException
+     */
+    public function __construct(string $serverName, array $serverConfig);
+
+    public function getAddress(): string;
+
+    public function getPort(): int;
+}

--- a/Client/UdpClient.php
+++ b/Client/UdpClient.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Client;
+
+class UdpClient implements ClientInterface
+{
+    /** @var int max safe size in bytes of one message to send (max official size is 65507) */
+    const MAX_MESSAGE_SIZE = 64000;
+
+    /** @var ServerInterface */
+    protected $server;
+
+    public function __construct(ServerInterface $server)
+    {
+        $this->server = $server;
+    }
+
+    /**
+     * Split metrics to send them group by group
+     *
+     * @param array $lines
+     */
+    public function sendLines(array $lines): void
+    {
+        $parts = array_chunk($lines, 30);
+        foreach ($parts as $linesToSend) {
+            $this->writeLines($linesToSend);
+        }
+    }
+
+    protected function writeLines(array $lines): bool
+    {
+        if ($resource = @fsockopen($this->server->getAddress(), $this->server->getPort())) {
+            foreach ($lines as $line) {
+                if (strlen($line) >= self::MAX_MESSAGE_SIZE) {
+                    // Ignore too big lines
+                    continue;
+                }
+
+                if (!@fwrite($resource, $line)) {
+                    return false;
+                }
+            }
+
+            if (fclose($resource)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/DataCollector/StatsdDataCollector.php
+++ b/DataCollector/StatsdDataCollector.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\DataCollector;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\MetricInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class StatsdDataCollector extends DataCollector
+{
+    /** @var array */
+    private $statsdClients;
+
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    /**
+     * Reset the data collector to initial state
+     */
+    public function reset()
+    {
+        $this->statsdClients = [];
+        $this->data = [
+            'clients' => [],
+            'operations' => 0,
+        ];
+    }
+
+    /**
+     * Kernel event
+     *
+     * @param Event $event The received event
+     */
+    public function onKernelResponse($event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST == $event->getRequestType()) {
+            foreach ($this->statsdClients as $clientName => $client) {
+                $clientInfo = [
+                    'name' => $clientName,
+                    'operations' => [],
+                ];
+                foreach ($client->getMetricHandler()->getMetrics() as $metric) {
+                    if ($metric instanceof MetricInterface) {
+                        try {
+                            $clientInfo['operations'][] = [
+                                'message' => $metric->toString(),
+                            ];
+                            $this->data['operations']++;
+                        } catch (MetricException $e) {
+                        }
+                    }
+                }
+                $this->data['clients'][] = $clientInfo;
+            }
+        }
+    }
+
+    /**
+     * Add a statsd client to monitor
+     *
+     * @param string $clientAlias  The client alias
+     * @param object $statsdClient A statsd client instance
+     */
+    public function addStatsdClient($clientAlias, $statsdClient)
+    {
+        $this->statsdClients[$clientAlias] = $statsdClient;
+    }
+
+    /**
+     * Collect the data
+     *
+     * @param Request    $request   The request object
+     * @param Response   $response  The response object
+     * @param \Exception $exception An exception
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+    }
+
+    /**
+     * Return the list of statsd operations
+     *
+     * @return array operations list
+     */
+    public function getClients()
+    {
+        return $this->data['clients'];
+    }
+
+    /**
+     * Return the number of statsd operations
+     *
+     * @return int the number of operations
+     */
+    public function getOperations()
+    {
+        return $this->data['operations'];
+    }
+
+    /**
+     * Return the name of the collector
+     *
+     * @return string data collector name
+     */
+    public function getName()
+    {
+        return 'statsd';
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * @var string
+     */
+    private $configurationRootKey;
+
+    public function __construct(string $configurationRootKey)
+    {
+        $this->configurationRootKey = $configurationRootKey;
+    }
+
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root($this->configurationRootKey);
+
+        $this->addServersSection($rootNode);
+        $this->addClientsSection($rootNode);
+        $this->addTagsSection($rootNode);
+        $this->addDefaultEventSection($rootNode);
+
+        return $treeBuilder;
+    }
+
+    private function addServersSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('servers')
+                    ->useAttributeAsKey('alias', false)
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('address')
+                                ->isRequired()
+                                ->validate()
+                                    ->ifTrue(function ($v) {return substr($v, 0, 6) !== 'udp://'; })
+                                    ->thenInvalid("address parameter should begin with 'udp://'")
+                                ->end()
+                            ->end()
+                            ->scalarNode('port')->isRequired()->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addClientsSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('clients')
+                    ->useAttributeAsKey('alias', false)
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('server')->cannotBeEmpty()
+                            ->end()
+                            ->arrayNode('groups')
+                                ->cannotBeEmpty()
+                                ->useAttributeAsKey('groupName')
+                                ->prototype('array')
+                                    ->children()
+                                        ->arrayNode('tags')
+                                            ->prototype('scalar')->end()
+                                        ->end()
+                                        ->append($this->getClientsGroupsEvents())
+                                    ->end()
+                                ->end()
+                            ->end()
+                            ->integerNode('to_send_limit')->min(1)->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addTagsSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('tags')
+                    ->prototype('scalar')->end()
+                ->end();
+    }
+
+    private function addDefaultEventSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->booleanNode('base_collectors')
+                    ->defaultFalse()
+                ->end()
+                ->booleanNode('console_events')
+                    ->defaultFalse()
+                ->end();
+    }
+
+    private function getClientsGroupsEvents()
+    {
+        return (new TreeBuilder())
+            ->root('events')
+            ->cannotBeEmpty()
+            ->useAttributeAsKey('eventName')
+            ->prototype('array')
+                ->children()
+                    ->booleanNode('flush_metrics_queue')->defaultFalse()->end()
+                    ->arrayNode('metrics')
+                        ->cannotBeEmpty()
+                        ->prototype('array')
+                            ->children()
+                                ->enumNode('type')->isRequired()->values(['increment', 'decrement', 'counter', 'gauge', 'timer'])->end()
+                                ->scalarNode('name')->isRequired()->end()
+                                ->scalarNode('param_value')->cannotBeEmpty()->end()
+                                ->arrayNode('tags')
+                                    ->prototype('scalar')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\DependencyInjection;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Client\UdpClient;
+use M6Web\Bundle\StatsdPrometheusBundle\Client\Server;
+use M6Web\Bundle\StatsdPrometheusBundle\DataCollector\StatsdDataCollector;
+use M6Web\Bundle\StatsdPrometheusBundle\Listener\ConsoleListener;
+use M6Web\Bundle\StatsdPrometheusBundle\Listener\EventListener;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\MetricHandler;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class M6WebStatsdPrometheusExtension extends Extension
+{
+    const CONFIG_ROOT_KEY = 'm6web_statsd_prometheus';
+
+    /** @var ContainerBuilder */
+    private $container;
+
+    /** @var array */
+    private $clientServiceIds = [];
+
+    /** @var array */
+    private $servers;
+
+    /** @var array */
+    private $clients;
+
+    /** @var array */
+    private $tags;
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $this->container = $container;
+
+        $loader = (new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config')));
+        $loader->load('services.yml');
+
+        $configuration = new Configuration(self::CONFIG_ROOT_KEY);
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $this->servers = $config['servers'] ?? [];
+        $this->clients = $config['clients'] ?? [];
+        $this->tags = $config['tags'] ?? [];
+
+        foreach ($this->clients as $alias => $clientConfig) {
+            $this->clientServiceIds[] = $this->setEventListenerAsServiceAndGetServiceId(
+                $alias,
+                $clientConfig,
+                $this->tags
+            );
+        }
+
+        $this->registerConsoleEventListener();
+
+        if ($this->container->hasParameter('kernel.debug')
+            && $this->container->getParameter('kernel.debug')) {
+            $this->loadDebugConfiguration();
+        }
+    }
+
+    public function getServers(): array
+    {
+        return $this->servers;
+    }
+
+    public function getClients(): array
+    {
+        return $this->clients;
+    }
+
+    public function getAlias(): string
+    {
+        return self::CONFIG_ROOT_KEY;
+    }
+
+    /**
+     * Load a client configuration as an event listener service in the container. A client can use multiple servers
+     *
+     * @param string $clientName   Alias set in the configuration for the current client
+     * @param array  $clientConfig Client config with servers config and groups config
+     * @param array  $tagsConfig   Optional tags defined at the top level
+     */
+    protected function setEventListenerAsServiceAndGetServiceId(
+        string $clientName, array $clientConfig, array $tagsConfig
+    ): string {
+        $serviceId = $this->getServiceIdFrom($clientName);
+
+        // Set the event listener service
+        $eventListenerDefinition = $this->getEventListenerDefinition($clientName, $clientConfig['server']);
+
+        // Parse config to add "event_listener" tag on the Listener
+        $this->addEventListenerTagsOnServiceDefinition($eventListenerDefinition, $clientConfig['groups'], $tagsConfig);
+
+        // Set the max number of metric to queue before sending them.
+        if (isset($clientConfig['max_queued_metrics'])) {
+            $eventListenerDefinition->addMethodCall('setMaxNumberOfMetricToQueue', [
+                $clientConfig['max_queued_metrics'],
+            ]);
+        }
+
+        // Add service to the container
+        $this->container->setDefinition($serviceId, $eventListenerDefinition);
+
+        return $serviceId;
+    }
+
+    protected function getServiceIdFrom(string $alias): string
+    {
+        return ($alias === 'default') ? self::CONFIG_ROOT_KEY : self::CONFIG_ROOT_KEY.$alias;
+    }
+
+    /**
+     * Add the "kernel event listener" tag on the given event listener service definition
+     *
+     * @param Definition $eventListenerDefinition
+     * @param array      $groupConfig
+     * @param array      $tagsConfig
+     */
+    protected function addEventListenerTagsOnServiceDefinition(
+        Definition $eventListenerDefinition, array $groupConfig, array $tagsConfig
+    ): void {
+        // Define event listener on events
+        foreach ($groupConfig as $eventsGroupName => $eventsGroupConfig) {
+            foreach ($eventsGroupConfig['events'] as $eventName => $eventConfig) {
+                foreach ($eventConfig['metrics'] as &$metricConfig) {
+                    // Parse each metric to get configuration tags (client and group tags)
+                    // Their values are defined in the configuration
+                    // Whereas metrics tags values are defined when the event is actually sent.
+                    // So, both "tags" types are handled differently.
+                    $metricConfig['configurationTags'] = \array_merge(
+                        $tagsConfig,
+                        $eventsGroupConfig['tags'] ?? []
+                    );
+                }
+                // Set all the metrics config array n the object
+                // One event can send several metrics. Multiple metrics will be handled in the Listener manager.
+                $eventListenerDefinition
+                    ->addTag('kernel.event_listener', [
+                        'event' => $eventName,
+                        'method' => 'handleEvent',
+                    ])
+                    ->addMethodCall('addEventToListen', [
+                        $eventName,
+                        $eventConfig,
+                    ]);
+            }
+        }
+        // Define event listener on kernel terminate
+        $eventListenerDefinition->addTag('kernel.event_listener', [
+            'event' => 'kernel.terminate',
+            'method' => 'onKernelTerminate',
+            'priority' => -100,
+        ]);
+    }
+
+    protected function loadDebugConfiguration(): void
+    {
+        $definition = new Definition(StatsdDataCollector::class);
+        $definition->setPublic(true);
+        $definition->addTag('data_collector', [
+            'template' => '@M6WebStatsd/Collector/statsd.html.twig',
+            'id' => 'statsd',
+        ]);
+
+        $definition->addTag('kernel.event_listener', [
+            'event' => 'kernel.response',
+            'method' => 'onKernelResponse',
+        ]);
+
+        foreach ($this->clientServiceIds as $serviceId) {
+            $definition->addMethodCall('addStatsdClient', [
+                $serviceId,
+                new Reference($serviceId),
+            ]);
+        }
+
+        $this->container->setDefinition('m6.data_collector.statsd', $definition);
+    }
+
+    protected function getEventListenerDefinition(string $clientName, string $serverName): Definition
+    {
+        return (new Definition(EventListener::class))
+            ->setPublic(true)
+            ->addMethodCall('setMetricHandler', [
+                $this->getMetricHandlerDefinition($clientName, $serverName),
+            ]);
+    }
+
+    protected function getMetricHandlerDefinition(string $clientName, string $serverName): Definition
+    {
+        return (new Definition(MetricHandler::class))
+            ->addMethodCall('setClient', [
+                $this->getMetricUdpClientDefinition($clientName, $serverName),
+            ]);
+    }
+
+    protected function getMetricUdpClientDefinition(string $clientName, string $serverName): Definition
+    {
+        return new Definition(UdpClient::class, [
+            $this->getClientServerDefinition($clientName, $serverName),
+        ]);
+    }
+
+    protected function getClientServerDefinition(string $clientName, string $serverName): Definition
+    {
+        // No server found.
+        if (!\array_key_exists($serverName, $this->servers)) {
+            throw new InvalidConfigurationException(sprintf(
+                'M6WebStatsd client %s used server %s which is not defined in the servers section',
+                $clientName,
+                $serverName
+            ));
+        }
+
+        // Matched server configurations.
+        return new Definition(Server::class, [
+            $serverName,
+            $this->servers[$serverName],
+        ]);
+    }
+
+    protected function registerConsoleEventListener(): void
+    {
+        $this->container
+            ->register('m6.listener.statsd.console', ConsoleListener::class)
+            ->addTag(
+                'kernel.event_listener',
+                ['event' => 'console.command', 'method' => 'onCommand']
+            )
+            ->addTag(
+                'kernel.event_listener',
+                ['event' => 'console.exception', 'method' => 'onException']
+            )
+            ->addTag(
+                'kernel.event_listener',
+                ['event' => 'console.terminate', 'method' => 'onTerminate']
+            )
+            ->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')]);
+    }
+}

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -1,0 +1,400 @@
+# Configuration
+
+## 1. Configure the servers
+
+### Description
+
+Add a `servers` option in the config file, and list all your UDP servers.
+
+```yaml
+m6web_statsd_prometheus:
+    servers:
+        default_server: #this is the root key / server name.
+            address: 'udp://localhost'
+            port: 1234
+        server1: #this is the root key / server name.
+            address: 'udp://localhost'
+            port: 1235
+        server2: #this is the root key / server name.
+            address: 'udp://localhost'
+            port: 1236   
+```
+
+### Server options
+
+* `{root key}` = server name
+
+You can name the server key in camelCase or snake_case.
+
+* `address`: string
+
+Address to the UDP server, containing the protocol.
+
+* `port`: int
+
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+## 2. Configure the clients
+
+### Description
+
+Now you need to set the clients and how they are linked to the defined servers.
+
+You need to add the `clients` option and detail as follow:
+
+```yaml
+m6web_statsd_prometheus:
+    servers:
+        default_server:
+            address: 'udp://localhost'
+            port: 1234
+        server1:
+            address: 'udp://localhost'
+            port: 1235
+        server2:
+            address: 'udp://localhost'
+            port: 1236
+    clients:
+        default_client: #this is the root key / client name.
+            max_queued_metrics: 10 #optional
+            server: 'default_server'
+        client1: #this is the root key / client name.
+            server: 'server1'
+        client2: #this is the root key / client name.
+            max_queued_metrics: 10000 #optional
+            server: 'server2'        
+```
+
+### Client options
+
+* `{root key}` = client name
+
+You can name the client key in camelCase or snake_case.
+
+* `server`: string
+
+Name of the server you want to use for that client.
+
+* `max_queued_metrics`: int (OPTIONAL)
+
+This is the limit of metrics we can queue before sending them to the UDP server.
+There is no limit by default.
+
+* `groups` : array
+
+See [3. Configure the groups](#3-configure-the-groups).
+
+
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+
+## 3. Configure the groups
+
+### Description
+
+With this new version, you have to define your events into groups.
+This offers a better clarity when you have a lot of events.
+
+
+```yaml
+m6web_statsd_prometheus:
+    clients:
+        default_client: #This is the client name            
+            server: 'default_server'
+            groups:
+                default_group: #this is the root key / group name.
+                    events:
+                        event1:
+                            [...]
+                        event2:
+                            [...]
+                ohter_group: #this is the root key / group name.
+                    events:
+                        event3:
+                            [...]
+                        event4:
+                            [...]
+```
+
+### Group options
+
+* `{root key}` = group name
+
+You can name the group key in camelCase or snake_case.
+
+* `events` : array
+
+See [4. Configure the events](#4-configure-the-events).
+
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+
+## 4. Configure the events
+
+### Description
+
+An event set up an event name, and metrics to send when it is called.
+
+```yaml
+m6web_statsd_prometheus:
+    clients:
+        default_client:            
+            server: 'default_server'
+            groups:
+                default_group:
+                    events:
+                        eventName1: #this is the root key / event name.
+                            flush_metrics_queue: true #Optional
+                            metrics: 
+                                - [...metric 1...]
+                                - [...metric 2...]
+                        eventName2: #this is the root key / event name.
+                            metrics: 
+                                - [...metric 1...]
+                                - [...metric 2...]
+                groupB: #This is an example name for a group
+                    events:
+                        eventName3: #this is the root key / event name.
+                            metrics: 
+                                - [...metric 1...]
+                                - [...metric 2...]
+                        eventName4: #this is the root key / event name.
+                            flush_metrics_queue: false #Optional (Default value)
+                            metrics: 
+                                - [...metric 1...]
+                                - [...metric 2...]
+```
+
+### Event options
+
+* `{root key}` = event name
+
+You can name the event key in camelCase or snake_case.
+
+* `flush_metrics_queue`: boolean \[optional. Default: false\]
+
+If this option is set to true, when this event is called, the queued metrics will be sent
+to the UDP server directly without waiting for the kernel terminate event. 
+
+* `metrics`: array
+
+See [5. Configure the metrics](#5-configure-the-metrics).
+
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+## 5. Configure the metrics
+
+### Description
+
+This is the main structure you need to use.
+
+> Note: It is now natively possible to send multiple metrics with one event.
+
+```yaml
+m6web_statsd_prometheus:
+    clients: 
+        default_client:
+            server: 'default_server'
+            groups:
+                default_group:
+                    events:
+                        eventName1:
+                            metrics:
+                                #This is the first metric definition
+                                -   type: 'counter'
+                                    name: 'first_metric_name'
+                                    param_value: 'metricValue'
+                                #This is the second metric definition   
+                                -   type: 'increment'
+                                    name: 'second_metric_name'
+                                    tags:
+                                       - 'additional_parameter'
+```
+
+### Metric options
+
+* `type`: string
+
+This is the metric type.
+ 
+ Available values are: 
+__counter, gauge, increment, decrement, timer__ 
+
+* `name`: string
+
+This is the metric name. You can name the metric with lower letters, numbers and underscores: __[a-z0-9\_]__.
+
+You are recommended to name the metrics in snake case. The statsd_exporter will transform 
+every of metric names in snake_case. It will be easier for you to find your metrics later if 
+the names are the same. 
+
+Metrics name must be __unique__. You cannot have the same metric name even if you have different types.
+The duplicated metric will be ignored.
+ 
+Placeholders (dynamic variables like __request.\<statusCode\>__) in metric names are now __deprecated__. 
+Prometheus does not allow to search on metric name with joker or regex. 
+You have to use __tags__ for this purpose (See [6. Configure the tags](#6-configure-the-tags) ). 
+
+* `param_value`: string
+
+This option defines which tag will return the metric value.
+This option is __required__ for gauge, counter, and timer types only.
+
+* `tags` : array
+
+See [6. Configure the tags](#6-configure-the-tags)
+ 
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+ 
+## 6. Configure the tags
+
+There are 3 types of tag that you can use: 
+* __global tag__: it is sent with every event metric. Its value is set in the config file.
+* __group tag__: it is sent with every event metric of the same group. Its value is set in the config file.
+* __metric tag__: it is sent only for the current event metric. Its value is sent with the event.  
+
+Here is an example of how to define those 3 types:
+```yaml
+m6web_statsd_prometheus:
+    tags: #Global tags
+        exampleTag: 'example_tag_Value' #value is required here
+        #Using global tags, we can inject the project name in every sent metrics
+        project: 'service_6play_users_cloud'        
+    
+    clients:
+        default_client:
+            server: 'default_server'
+            groups:
+                default_group:
+                    tags: #Group tags: only for current group
+                        tag1GroupA: 'tagValueB' #value is required here
+                        tag2GroupA: 'tagValueB'
+                    events:
+                        eventName1:
+                            metrics:
+                                -   type: 'counter'
+                                    name: 'metricName'
+                                    param_value: 'counterValue'
+                                    tags: 
+                                        #Metric tags: only for the current event,
+                                        #only labels are set
+                                        #values are defined when the event is sent
+                                        - 'tag1Event1Label'
+                                        - 'tag2Event1Label'
+                        eventName12:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'metricName'
+                                    tags: 
+                                        #Metric tags: only for the current event
+                                        - 'tag1Event2'                                                                  
+```
+
+### :warning: Modifying configuration requires statsd_exporter reboot
+
+Once you've sent a metric, if you change its configuration, changes will be ignored. 
+
+You will need to reboot the statsd_exporter server in order to take into account the new changes.
+
+### Send tags with event metrics
+
+When you set a tag in a metric, the bundle will look for an associated value to return.
+
+If you use the new format, it will look for a parameter named after your tag.
+
+A compatibility fallback will automatically look into your event object, to see if there is a public 
+accessor associated to your tag name. This works like the former placeholders. 
+
+See [Usage documentation](usage.md) for further explanations. 
+ 
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+## 7. Compatibility and legacy behaviour
+
+### Modify your configuration format
+
+If you want to use this bundle in a project that used the former StatsdBundle, you will need to perform
+a few changes in your configuration file, to adapt it to this new format (See chapters 1 to 6).
+
+Here is an old configuration sample:
+```yaml
+m6_statsd:
+    servers:
+        default_server:
+            address: 'udp://127.0.0.1'
+            port: 8125
+    clients:
+        default:
+            server: 'default_server'
+            events:
+                kernel.terminate:
+                    increment: 'request.service-6play-broadcast.<request_host>.<response_statusCode>'
+                kernel.exception:
+                    increment: 'errors.<exception.code>.service-6play-broadcast.error'
+                redis.command:
+                    increment: 'cache.redis.composant.<command>.service-6play-broadcast'
+                m6web.guzzlehttp:
+                    timing: 'guzzlehttp.service-6play-broadcast.<clientId>'
+                    increment: 'guzzlehttp.service-6play-broadcast.<clientId>.<response_statusCode>'
+``` 
+This is how you need to change it:
+```yaml
+m6web_statsd_prometheus:
+    servers:
+        default_server:
+            address: 'udp://127.0.0.1'
+            port: 8125
+    tags:
+        #this will inject the project name in all metrics automatically. 
+        #Use snake case.
+        project: 'service_6play_broadcast'         
+    clients:
+        default_client:
+            server: 'default_server'
+            groups:
+                default_gruop:
+                    events:
+                        kernel.terminate:
+                            metrics:
+                                -   type: 'increment'
+                                    #project name and dynamics values are removed here for the metric name
+                                    name: 'request' 
+                                    tags: #dynamic values are set in tags
+                                        - 'request_host'
+                                        - 'response_statusCode'
+                        kernel.exception:
+                            metrics:
+                                -   type: 'increment'
+                                    #this name below is not very relevant now. 
+                                    #'error' would be enough probably.
+                                    name: 'errors.error' 
+                                    tags:
+                                        - 'exception.code'
+                        redis.command:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'cache.redis.composant'
+                                    tags:
+                                        - 'command'
+                        m6web.guzzlehttp:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'guzzlehttp'
+                                    #this parameter will match with the public function set in the sent event
+                                    param_value: 'getTiming' 
+                                    tags:
+                                        - 'clientId'
+                                                                        
+                                -   type: 'increment'
+                                    #when removing placeholders, the metric name is same than the above timer
+                                    #so we had to change it
+                                    name: 'guzzlehttp_increment'  
+                                    tags:
+                                        - 'clientId'
+                                        - 'response_statusCode'
+```
+
+> :information_source: For further help, have a look at the [Examples](examples.md) section.
+
+[Go back](../README.md)

--- a/Doc/contribution.md
+++ b/Doc/contribution.md
@@ -1,0 +1,28 @@
+# Contribution
+
+## Contribution
+
+@TDODO
+
+## Run Unit Tests
+
+This projects is given with unit testing and code style checking.
+
+Run code style checking :
+```bash
+make php-cs
+make php-ci
+```
+
+Run tests with phpunit :
+```bash
+make phpunit
+```
+
+Run both code style checking and unit tests:
+```bash
+make test
+```
+
+
+[Go back](../README.md)

--- a/Doc/examples.md
+++ b/Doc/examples.md
@@ -1,0 +1,639 @@
+# Examples
+
+
+## Example 1: Full configuration file example
+
+```yaml
+m6web_statsd_prometheus:
+    servers:
+        default:
+            address: 'udp://localhost'
+            port: 1236
+    tags:
+        tagA: 'tagValue1'
+        tagB: 'tagValue2'
+    clients: #clients
+        default:
+            max_queued_metrics: 10000 #optional
+            server: 'default'
+            groups: #groups
+                groupA:
+                    tags:
+                        tagC: 'tagValue3'
+                        tagD: 'tagValue4'
+                    events: #events types
+                        eventName1:
+                            metrics:
+                                -   type: 'counter'
+                                    name: 'metric_name'
+                                    param_value: 'counterValue'
+                                    tags:
+                                        - 'tagE'
+                                        - 'tagF'
+                        eventName2:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'gauge'
+                                    name: 'metric_name2'
+                                    param_value: 'gaugeValue'
+                                -   type: 'increment'
+                                    name: 'metric_name21_some_option'
+                groupB:
+                    tags:
+                        tagE: 'tagValue5'
+                        tagF: 'tagValue6'
+                    events: #events types
+                        eventName3:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'metric_name3'
+                        eventName4:
+                            metrics:
+                                -   type: 'decrement'
+                                    name: 'metric_name4'
+                                    tags:
+                                        - 'tagE'
+                        eventName5:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'metric_name5'               
+```
+
+## Example 2: Sending an increment or decrement metric
+
+Configuration example:
+
+```yaml
+event1:
+    metrics:
+        -
+          type: 'increment'
+          name: 'http_200'
+          tags: 
+            - 'myTagLabel1'
+            - 'myTagLabel2'
+```
+This is the code you can send:
+```php
+// Without sending the tags (they'll be ignored)
+$eventDispatcher->dispatch('event1', new MonitoringEvent());
+
+// With sending the tags
+$eventDispatcher->dispatch('event1', new MonitoringEvent([
+    'myTagLabel1' => 'myTag_value1',
+    'myTagLabel2' => 'myTag_value2',
+]));
+```
+
+## Example 3: Sending a counter, gauge or timing metric
+
+Configuration example:
+
+```yaml
+event1:
+    metrics:
+        -
+          type: 'counter'
+          name: 'http_200'
+          param_value: 'myCounterValue'
+          tags: 
+            - 'myTagLabel1'
+            - 'myTagLabel2'
+```
+This is the code you can send:
+```php
+// Without sending the tags (they'll be ignored)
+$eventDispatcher->dispatch('event1', new MonitoringEvent([
+    'myCounterValue' => 1234,
+]));
+
+// With sending the tags
+$eventDispatcher->dispatch('event1', new MonitoringEvent([   
+    'myCounterValue' => 1234,
+    'myTagLabel1' => 'myTag_value1',
+    'myTagLabel2' => 'myTag_value2',
+]));
+```
+
+## Example 4: Sending multiple metrics in one event
+
+In the config file, you can define:
+```yaml
+event1:
+    metrics:
+        -   type: 'increment'
+            name: 'number_of_executed_queries'
+            tags:
+                - customTag1
+        -   type: 'timing'
+            name: 'queries_time_spent'
+            param_value: 'executionTimeValue'
+            tags:
+                - customTag2
+        -   type: 'counter'
+            name: 'number_of_results'
+            param_value: 'numberOfResults'                        
+```
+
+This is the event definition you can dispatch:
+```php
+// Without sending the tags (they will be ignored)
+$eventDispatcher->dispatch('event1', new MonitoringEvent([
+    'executionTimeValue' => 1234,
+    'numberOfResults' => 42,
+]));
+
+// With sending the tags
+$eventDispatcher->dispatch('event1', new MonitoringEvent([    
+    'executionTimeValue' => 1234,
+    'numberOfResults' => 42,
+    'customTag1' => 'the tag1 value',
+    'customTag2' => 'the tag2 value',
+]));
+```
+
+## Example 5: Replacing placeholders (in the metric name)
+
+You cannot use dynamic values in your metric name anymore. You have to use tags.
+
+Old placeholders functions will be working as tags.
+
+In the config file, you can define:
+```yaml
+event1:
+    metrics:
+        -
+          type: 'increment'
+          name: 'request'
+          tags:
+            - 'statusCode'
+        -
+          type: 'counter'
+          name: 'country_view'
+          param_value: 'countryCounter'
+          tags:
+            - 'country'
+```
+
+This is the event definition you can dispatch (the new way):
+```php
+// Without sending the tags (they will be ignored)
+$eventDispatcher->dispatch('event1', new MonitoringEvent([
+    'statusCode' => $this->getHttpCode(),
+    'country' => 'france',
+    'countryCounter' => $this->getCountryCounter(),
+]));
+
+// With sending the tags
+$eventDispatcher->dispatch('event1', new MonitoringEvent([
+    'code' => $this->getHttpCode(),
+    'country' => 'france',
+    'countryCounter' => $this->getCountryCounter(),
+    'customTag1' => 'the tag1 value',
+]));
+```
+
+This is the event definition you can dispatch (old-fashioned way):
+```php
+// Without sending the tags (they will be ignored)
+$eventDispatcher->dispatch('event1', new CustomEvent(
+    $this->getHttpCode(),
+    'france',
+    $this->getCountryCounter()
+));
+
+// CustomEvent.php
+class CustomEvent {
+
+    private $code;
+    private $country;
+    private $countryCounter;
+
+    public function __construct($code, $country, $countryCounter) 
+    {
+        $this->code = $code;
+        $this->country = $country;
+        $this->countryCounter = $countryCounter;
+    }
+    
+    public function getStatusCode()
+    {
+       return $this->code;
+    }
+    
+    public function getCountry()
+    {
+       return $this->country;
+    }
+    
+    public function getCountryCounter()
+    {
+       return $this->countryCounter;
+    }
+}
+```
+## Example 6: transforming a configuration file (service-6play-users case)
+
+Old one : 
+
+```yaml
+m6_statsd:
+    servers:
+        default:
+            address: 'udp://%statsd.address%'
+            port: '%statsd.port%'
+    console_events: true
+    clients:
+        default:
+            servers: ['all']
+            events:
+                uniqu_anonymous_id:
+                    increment:     service.service-6play-users.uniqanonymousid.<platform>
+                m6kernel.terminate:
+                    increment:     request.service-6play-users.<status_code>.<route_name>
+                    timing:        request.service-6play-users.<status_code>.<route_name>
+                    custom_timing: { node: memory.service-6play-users.<status_code>.<route_name>, method: getMemory }
+                m6kernel.exception:
+                    increment: errors.<status_code>.service-6play-users
+                m6video.user_box.pairing:
+                    increment: service.service-6play-users.user_box.<platformCode>.<status>
+                m6video.auto_pairing:
+                    increment: service.service-6play-users.auto_pairing.<network>.<status>
+                m6video.redis.list.size:
+                    timing: service.service-6play-users.<customer>.command.<command>.redis.list.size
+                m6video.command.clean_deleted_tests:
+                    increment: service.service-6play-users.command.clean_deleted_tests.<value>
+                    immediate_send: true
+                m6video.command.export_user_data.send.error:
+                    increment: service.service-6play-users.<customer>.command.export_user_data.send.error
+                m6video.command.client.error:
+                    increment: service.service-6play-users.<customer>.command.<command>.send.error.<value>
+                m6video.command.redis.error:
+                    increment: service.service-6play-users.<customer>.command.<command>.redis.error
+                m6video.command.import_user_data.client.error:
+                    increment: service.service-6play-users.command.import_user_data.error.<value>
+                m6video.command:
+                    increment: service.service-6play-users.<customer>.command.<command>.<value>
+                m6video.krux.segments.error:
+                    increment: service.service-6play-users.krux.segments.error.<platformCode>.<value>
+                m6video.sms.send:
+                    increment: service.service-6play-users.sms.<provider>.<type>.<success>.<code>
+                m6video.krux.call:
+                    timing:    service.service-6play-users.krux.call.<route>.<platformCode>.<value>
+                    increment: service.service-6play-users.krux.call.<route>.<platformCode>.<value>
+                m6video.gigya.notifications:
+                    increment: service.service-6play-users.gigya.notifications.<value>
+                m6video.store.request:
+                    timing: service.service-6play-users.store.validation.<platformCode>.<storeCode>.<statusCode>
+                m6video.store.validation.error:
+                    increment: service.service-6play-users.store.validation.<platformCode>.<storeCode>.error.<value>
+                m6video.store.validation.success:
+                    increment: service.service-6play-users.store.validation.<platformCode>.<storeCode>.success
+                m6video.store.freemium_pack.active:
+                    increment: service.service-6play-users.store.freemium_pack.<platformCode>.<storeCode>.<active>
+                m6video.import.status:
+                    increment: service.service-6play-users.import.<keyspace>.<table>.<status>
+                    immediate_send: true
+                applaunch.client.error:
+                    increment: applaunch.server.error.service-6play-users
+                applaunch.client.success:
+                    increment: applaunch.server.success.service-6play-users
+                m6video.mindbaz.export:
+                    increment: service.service-6play-users.mindbaz.export.<type>.<value>
+                m6video.client.release:
+                    increment: service.service-6play-users.client.release.<platformCode>.<release>
+                m6video.user.delete:
+                    increment: service.service-6play-users.user.delete.<value>
+
+                m6web.cassandra:
+                    timing: service.service-6play-users.cassandra.all_keyspaces.<command>
+
+                redis.command:
+                    increment: cache.redis.composant.<command>.service-6play-users
+                    timing   : cache.redis.composant.<command>.service-6play-users
+
+                daemon.loop.iteration:
+                    increment:      worker.service-6play-users.<command>.iteration
+                    timing:         worker.service-6play-users.<command>.iteration
+                    custom_timing:  { node: memory.service-6play-users.worker.<command>.iteration, method: getMemory }
+                daemon.stop:
+                    immediate_send: true
+
+                daemon.iteration.statsd.immediatesend:
+                    immediate_send: true
+
+```
+New one : 
+```yaml
+m6web_statsd_prometheus:
+
+    servers:
+        default_server:
+            address: 'udp://%statsd_prometheus.address%'
+            port: '%statsd_prometheus.port%'
+
+    tags:
+        project: 'service_6play_users'
+
+    # Clients definition
+    clients:
+
+        # Default client
+        default_client:
+            server: 'default_server'
+            groups:
+
+                # Default group
+                default_group:
+                    events:
+
+                        uniqu_anonymous_id:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'uniqanonymousid'
+                                    tags:
+                                        - 'platform'
+
+                        m6kernel.terminate:
+                            metrics:                                
+                                # increment:     request.service-6play-users.<status_code>.<route_name>
+                                # /!\ Increment event here is useless:
+                                # => A counter is already provided by prometheus with the other metric
+                                -   type: 'timer'
+                                    name: 'request'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'statusCode'
+                                        - 'routeName'
+
+                                -   type: 'timer'
+                                    name: 'memory'
+                                    param_value: 'getMemory'
+                                    tags:
+                                        - 'statusCode'
+                                        - 'routeName'
+
+                        m6web.console.command:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_run'
+                                    tags:
+                                        - 'underscoredCommandName'
+
+                        m6web.console.exception:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_exception'
+                                    tags:
+                                        - 'underscoredCommandName'
+
+                        m6web.console.terminate:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'command_exception'
+                                    param_value: 'executionTimeHumanReadable'
+                                    tags:
+                                        - 'underscoredCommandName'
+
+                        m6kernel.exception:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'errors'
+                                    tags:
+                                        - 'statusCode'
+
+                        m6video.user_box.pairing:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'user_box'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'status'
+
+                        m6video.auto_pairing:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'auto_pairing'
+                                    tags:
+                                        - 'network'
+                                        - 'status'
+
+                        m6video.redis.list.size:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'command_redis_list_size'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+
+                        m6video.command.clean_deleted_tests:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_clean_deleted_tests'
+                                    tags:
+                                        - 'value'
+
+                        m6video.command.export_user_data.send.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_export_user_data_send_error'
+                                    tags:
+                                        - 'customer'
+
+                        m6video.command.client.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_send_error'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+                                        - 'value'
+
+                        m6video.command.redis.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_redis_error'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+
+                        m6video.command.import_user_data.client.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command_import_user_data_error'
+                                    tags:
+                                        - 'value'
+
+                        m6video.command:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+                                        - 'value'
+
+                        m6video.krux.segments.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'krux_segments_error'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'value'
+
+                        m6video.sms.send:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'sms'
+                                    tags:
+                                        - 'provider'
+                                        - 'type'
+                                        - 'success'
+                                        - 'code'
+
+                        m6video.krux.call:
+                            metrics:                            
+                                # increment: krux.call.<route>.<platformCode>.<value>
+                                # /!\ Increment event here is useless:
+                                # => A counter is already provided by prometheus with the other metric
+                                -   type: 'timer'
+                                    name: 'krux_call'
+                                    param_value: 'geTiming'
+                                    tags:
+                                        - 'route'
+                                        - 'platformCode'
+                                        - 'value'
+
+                        m6video.gigya.notifications:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'gigya_notifications'
+                                    tags:
+                                        - 'value'
+
+                        m6video.store.request:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'store_validation'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+                                        - 'statusCode'
+
+                        m6video.store.validation.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'store_validation_error'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+                                        - 'value'
+
+                        m6video.store.validation.success:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'store_validation_success'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+
+                        m6video.store.freemium_pack.active:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'store_freemium_pack'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+                                        - 'active'
+
+                        m6video.import.status:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'import'
+                                    tags:
+                                        - 'keyspace'
+                                        - 'table'
+                                        - 'status'
+
+                        applaunch.client.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'applaunch_server_error'
+
+                        applaunch.client.success:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'applaunch_server_success'
+
+                        m6video.mindbaz.export:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'mindbaz_export'
+                                    tags:
+                                        - 'type'
+                                        - 'value'
+
+                        m6video.client.release:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'client_release'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'release'
+
+                        m6video.user.delete:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'user_delete'
+                                    tags:
+                                        - 'value'
+
+                        m6web.cassandra:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'cassandra_all_keyspaces'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'command'
+
+                        redis.command:
+                            metrics:
+                                # increment: cache.redis.composant.<command>.service-6play-users
+                                # /!\ Increment event here is useless:
+                                # => A counter is already provided by prometheus with the other metric                                
+                                -   type: 'timer'
+                                    name: 'cache_redis_composant'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'command'
+
+                        daemon.loop.iteration:
+                            metrics:                                
+                                # increment: worker.service-6play-users.<command>.iteration
+                                # /!\ Increment event here is useless:
+                                # => A counter is already provided by prometheus with the other metric
+                                -   type: 'timer'
+                                    name: 'worker_iteration'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'command'
+
+                                -   type: 'timer'
+                                    name: 'memory_worker_iteration'
+                                    param_value: 'getMemory'
+                                    tags:
+                                        - 'command'
+
+                        daemon.stop:
+                            flush_metrics_queue: true
+
+                        daemon.iteration.statsd.immediatesend:
+                            flush_metrics_queue: true
+```
+[Go back](../README.md)

--- a/Doc/installation.md
+++ b/Doc/installation.md
@@ -1,0 +1,55 @@
+# Installation
+
+## Install with composer
+```bash
+composer require m6web/statsd-prometheus-bundle
+```
+
+## Symfony <4
+
+## Register the bundle
+
+```php
+// app/AppKernel.php
+[
+    // ...Other bundles...
+    new M6Web\Bundle\StatsdPrometheusBundle\M6WebStatsdPrometheusBundle(),
+    // ...Other bundles...
+]
+```
+
+## Set the configuration key
+Create a file named, for example, `m6web_statsd_prometheus.yml` and add the config root key in a config file:
+```yaml
+#app/config/m6web_statsd_prometheus.yml
+m6web_statsd_prometheus: ~
+```
+Include this file in your main config file:
+```yaml
+#app/config/config.yml
+- { resource: m6web_statsd_prometheus.yml }
+```
+
+## Symfony >=4
+
+## Register the bundle (if automatic addition has failed)
+
+```php
+// config/bundles.php
+return [
+    // ...Other bundles...
+    M6Web\Bundle\StatsdPrometheusBundle\M6WebStatsdPrometheusBundle::class => ['all' => true]
+    // ...Other bundles...
+];
+```
+
+## Add the configuration file
+Create a file named `config/packages/m6web_statsd_prometheus.yaml` and add 
+the config root key in a config file:
+```yaml
+#config/packages/statsd_prometheus.yml
+m6web_statsd_prometheus: ~
+```
+
+
+[Go back](../README.md)

--- a/Doc/prometheus-grafana.md
+++ b/Doc/prometheus-grafana.md
@@ -1,0 +1,73 @@
+Prometheus in Grafana 
+======
+
+(:warning: Work in progress)
+
+Getting started with Prometheus
+------
+
+### Configuration example
+
+This is how you configured your event:
+```yaml
+m6web_statsd_prometheus:
+    servers: [...]
+    tags:
+        project: 'service_6play_users_cloud'
+    clients:
+        default_client:
+            server: 'default_server'
+            groups:
+                default_group:
+                    events:
+                        m6kernel.terminate:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'http_request'
+                                    tags:
+                                        - 'statusCode'
+                                        - 'routeName'
+```
+In `statusCode` tag, you will return the HTTP code, and in  `routeName` tag you will return the route name.
+
+### Search for a metric with tags
+
+When you want to look for a metric, you have to give the full metric name.
+It is not possible with prometheus to look for a partial metric name, 
+like we use to do with Graphite.
+
+So, if you are looking for:
+
+* `http`: :x: you won't find any value
+* `.*request.*` (with Regex): :x: you will have an error 
+* `http_request`: :heavy_check_mark: you will find your values
+
+With Prometheus, you need to use `tags` to perform your researches.
+
+In order to get every __http_request__ metrics sent for __service_6play_users_cloud__ project:
+
+`http_request{project="service_6play_users_cloud"}`
+
+Maybe you want to filter and get only metrics with an HTTP Code 200:
+
+`http_request{project="service_6play_users_cloud",statusCode="200"}`
+
+If you want to get this result only for the __status__ soute:
+
+`http_request{project="service_6play_users_cloud",statusCode="200",routeName="status"}`
+
+
+### Automatic sums and counts
+
+For each metric, Prometheus will provide a counter and a sum of your metric.
+
+It is easy to find, you just have to add `_sum` or `_count` to get this compiled metric.
+
+So, we can find those two metrics:
+* `http_request_count`: that will display the number of times this metric has been called since the beginning
+* `http_request_sum`: this will provide the sum of each metric value since the beginning.
+
+@TODO
+==============
+
+équivalence avec statsd

--- a/Doc/usage.md
+++ b/Doc/usage.md
@@ -1,0 +1,95 @@
+# Usage
+
+## Dispatch your events
+
+### Using MonitorableEventInterface
+
+For every new event you need to dispatch, you have to use a class that implements 
+`M6Web\Bundle\StatsdPrometheusBundle\Events\MonitorableEventInterface`.
+
+This bundle offers you a generic implementation called
+ `M6Web\Bundle\StatsdPrometheusBundle\Events\MonitorableEvent` that will handle most of your needs.
+ So you won't need to create your own events anymore. You can use this class to send your events
+  directly like this:
+ 
+ ```php
+ // Simple example without tags
+ $eventDispatcher->dispatch('event1', new MonitoringEvent());
+ 
+ // Simple example with tags
+ $eventDispatcher->dispatch('event1', new MonitoringEvent([
+     'myTagLabel1' => 'myTag_value1',
+     'myTagLabel2' => 'myTag_value2',
+ ]));
+ 
+ // Example with tags and param value
+  $eventDispatcher->dispatch('event1', new MonitoringEvent([
+      'myTagLabel1' => 'myTag_value1',
+      'myTagLabel2' => 'myTag_value2',
+      // Defined param value
+      'myCustomParamValue' => 'myValue',
+  ]));
+ ```
+
+#### :warning: Warning
+
+If you really need to create a specific event (for personal reasons), you can define your own class, 
+but make sure that it will implement `MonitorableEventInterface`.
+
+### Other events and legacy behaviour
+
+If you need to use this bundle on an existing application, you are asked to perform a few changes 
+in the configuration file of you application.
+
+We have worked on compatibility with existing applications to prevent changes in any application code.
+
+See [Configuration \> 7. Compatibility and legacy behaviour](configuration.md#7-compatibility-and-legacy-behaviour)
+
+> For further help, have a look at the [Examples](examples.md) section.
+
+
+## Best practices
+
+```yaml
+m6web_statsd_prometheus:
+
+    servers:
+        #Use explicit default naming
+        default_server:
+            address: "udp://localhost"
+            port: 9125
+          
+    #Global tags  
+    tags:         
+        #Using global tags, we can inject the project name in every sent metrics
+        project: 'service_6play_users_cloud'        
+    
+    clients:
+        #Use explicit default naming
+        default_client:
+            server: 'default_server'
+            groups:
+                default_group:
+                    [...]
+```
+
+### 1. Use explicit default parameter name
+
+Sometimes, you don't know how to name a parameter. So, you would like to use `default` as a name.
+It can be confusing to se only "default" value everywhere. It would be better to use explicit naming,
+ to understand what "default" stands for :
+ * default_server 
+ * default_client
+ * default_group
+ * ...
+
+
+### 2. Add a global tag to set project name
+
+Add a global tag named `project` to inject the project name in every metric that you will send.
+
+Name your project in `snake_case`:
+ * __service-6play-users__ becomes __service_6play_users__
+
+
+[Go back](../README.md)

--- a/Event/MonitoringConsoleEvent.php
+++ b/Event/MonitoringConsoleEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
+
+class MonitoringConsoleEvent extends MonitoringEvent
+{
+    const COMMAND = 'm6web.console.command';
+    const TERMINATE = 'm6web.console.terminate';
+    const ERROR = 'm6web.console.error';
+    const EXCEPTION = 'm6web.console.exception';
+}

--- a/Event/MonitoringEvent.php
+++ b/Event/MonitoringEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class MonitoringEvent extends Event implements MonitoringEventInterface
+{
+    /** @var array */
+    private $parameters;
+
+    public function __construct(array $parameters = [])
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function hasParameter(string $key): bool
+    {
+        return isset($this->parameters[$key]);
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getParameter(string $key)
+    {
+        return $this->parameters[$key] ?? null;
+    }
+}

--- a/Event/MonitoringEventInterface.php
+++ b/Event/MonitoringEventInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
+
+interface MonitoringEventInterface
+{
+    /**
+     * MonitoringEvent constructor.
+     *
+     * @param array $parameters parameters can contains metrics values, tags values or/and custom param values
+     *
+     * @see https://github.com/M6Web/StatsdPrometheusBundle/blob/master/Doc/usage.md
+     */
+    public function __construct(array $parameters = []);
+
+    public function hasParameter(string $key): bool;
+
+    /**
+     * @return mixed|null
+     */
+    public function getParameter(string $key);
+}

--- a/Exception/MetricException.php
+++ b/Exception/MetricException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Exception;
+
+class MetricException extends \Exception
+{
+}

--- a/Exception/ServerException.php
+++ b/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Exception;
+
+class ServerException extends \Exception
+{
+}

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 M6Web
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Listener/ConsoleListener.php
+++ b/Listener/ConsoleListener.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Listener;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringConsoleEvent;
+use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ConsoleListener
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher = null;
+
+    /**
+     * Time when command started
+     *
+     * @var float
+     */
+    protected $startTime = null;
+
+    public function onCommand(ConsoleEvent $event): void
+    {
+        $this->startTime = microtime(true);
+        $this->dispatchConsoleEvent(MonitoringConsoleEvent::COMMAND, $event);
+    }
+
+    public function onTerminate(ConsoleTerminateEvent $event): void
+    {
+        // For non-0 exit command, fire an ERROR event
+        if ($event->getExitCode() != 0) {
+            $this->dispatchConsoleEvent(MonitoringConsoleEvent::ERROR, $event);
+        }
+        $this->dispatchConsoleEvent(MonitoringConsoleEvent::TERMINATE, $event);
+    }
+
+    public function onException(ConsoleEvent $event): void
+    {
+        $this->dispatchConsoleEvent(MonitoringConsoleEvent::EXCEPTION, $event);
+    }
+
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
+    {
+        $this->eventDispatcher = $eventDispatcher;
+
+        return $this;
+    }
+
+    protected function dispatchConsoleEvent($eventName, ConsoleEvent $event): void
+    {
+        if (!is_null($this->eventDispatcher)) {
+            $executionTime = !is_null($this->startTime) ? microtime(true) - $this->startTime : null;
+            $finaleEvent = new MonitoringConsoleEvent([
+                'startTime' => $this->startTime,
+                'executionTime' => $executionTime,
+                'executionTimeHumanReadable' => ($executionTime * 1000),
+                'peakMemory' => self::getPeakMemory(), // @todo: not sure that it's useful
+                'underscoredCommandName' => self::getUnderscoredEventCommandName($event),
+                // The original event is sent as a parameter, just in case
+                'originalEvent' => $event,
+            ]);
+            $this->eventDispatcher->dispatch($eventName, $finaleEvent);
+        }
+    }
+
+    private static function getUnderscoredEventCommandName(ConsoleEvent $event): ?string
+    {
+        if (!is_null($command = $event->getCommand())) {
+            return str_replace(':', '_', $command->getName());
+        }
+
+        return null;
+    }
+
+    private static function getPeakMemory()
+    {
+        $memory = memory_get_peak_usage(true);
+        $memory = ($memory > 1024 ? intval($memory / 1024) : 0);
+
+        return $memory;
+    }
+}

--- a/Listener/EventListener.php
+++ b/Listener/EventListener.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Listener;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\Metric;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\MetricHandler;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\PropertyAccess;
+
+class EventListener
+{
+    protected $listenedEvents = [];
+
+    /** @var PropertyAccess\PropertyAccessorInterface */
+    protected $propertyAccessor;
+
+    /** @var MetricHandler */
+    protected $metricHandler;
+
+    /**
+     * @param mixed  $event     Event object sent with the event dispatcher
+     * @param string $eventName name of the event set in the config
+     */
+    public function handleEvent($event, string $eventName): void
+    {
+        if (!isset($this->listenedEvents[$eventName])) {
+            return;
+        }
+        $eventConfig = $this->listenedEvents[$eventName];
+        if (isset($eventConfig['flush_metrics_queue'])) {
+            $this->metricHandler->setFlushMetricsQueue($eventConfig['flush_metrics_queue']);
+        }
+
+        foreach ($eventConfig['metrics'] as $metricConfig) {
+            //In a few cases, we need to handle events without metrics.
+            //Those events are mainly "flush events", used to send immediately the queued metrics.
+            $this->metricHandler->addMetricToQueue(
+                (new Metric($event, $metricConfig))
+            );
+        }
+
+        // We ask for the metric handler to try to send the message
+        // "Try" means that the handler has to follow some rules, and if those rules are not valid,
+        // It won't send anything. The handler knows its job.
+        $this->metricHandler->tryToSendMetrics();
+    }
+
+    /**
+     * method called on the kernel.terminate event
+     */
+    public function onKernelTerminate(PostResponseEvent $event): void
+    {
+        $this->metricHandler->sendMetrics();
+    }
+
+    public function addEventToListen(string $eventName, array $eventConfig): self
+    {
+        $this->listenedEvents[$eventName] = $eventConfig;
+
+        return $this;
+    }
+
+    public function setMetricHandler(MetricHandler $metricHandler): self
+    {
+        $this->metricHandler = $metricHandler;
+
+        return $this;
+    }
+
+    public function getMetricHandler(): MetricHandler
+    {
+        return $this->metricHandler;
+    }
+}

--- a/M6WebStatsdPrometheusBundle.php
+++ b/M6WebStatsdPrometheusBundle.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class M6WebStatsdPrometheusBundle extends Bundle
+{
+    /**
+     * trick allowing bypassing the Bundle::getContainerExtension check on getAlias
+     * not very clean, to investigate
+     *
+     * @return object DependencyInjection\M6WebStatsdExtension
+     */
+    public function getContainerExtension()
+    {
+        return new DependencyInjection\M6WebStatsdPrometheusExtension();
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+SHELL=bash
+SOURCE_DIR = $(shell pwd)
+BASE_DIR = ${SOURCE_DIR}/..
+BIN_DIR ?= ${SOURCE_DIR}/bin
+LOGS_DIR = ${BASE_DIR}/build/logs
+COMPOSER_DIR = ${SOURCE_DIR}/composer
+COMPOSER_BIN := $(shell type -P composer)
+
+ifndef COMPOSER_BIN
+    COMPOSER_BIN = ${COMPOSER_DIR}/composer.phar
+endif
+
+test: cs-ci phpunit
+
+define printSection
+    @printf "\033[36m\n==================================================\n\033[0m"
+    @printf "\033[36m $1 \033[0m"
+    @printf "\033[36m\n==================================================\n\033[0m"
+endef
+
+# TEST
+phpunit:
+	$(call printSection,PHPUNIT)
+	${BIN_DIR}/simple-phpunit
+
+phpunit-cc:
+	$(call printSection,PHPUNIT)
+	${BIN_DIR}/simple-phpunit --coverage-text
+
+# QUALITY
+cs:
+	$(call printSection,CS)
+	${BIN_DIR}/php-cs-fixer fix --ansi --dry-run --stop-on-violation --diff
+
+cs-fix:
+	$(call printSection,CS-fix)
+	${BIN_DIR}/php-cs-fixer fix --ansi
+
+cs-ci:
+	$(call printSection,CS-CI)
+	${BIN_DIR}/php-cs-fixer fix --ansi --dry-run --using-cache=no --verbose

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Metric;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEventInterface;
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class Metric implements MetricInterface
+{
+    const TYPE_COUNTER = 'c';
+    const TYPE_GAUGE = 'g';
+    const TYPE_TIMER = 'ms';
+
+    /** @var PropertyAccess */
+    protected $propertyAccessor;
+
+    /** @var mixed|Event */
+    private $event;
+
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $type;
+
+    /** @var string */
+    private $paramValue;
+
+    /** @var array */
+    private $configurationTags;
+
+    /** @var array */
+    private $tags;
+
+    /**
+     * Metric constructor.
+     *
+     * @param Event|mixed $event
+     * @param array       $metricConfig
+     */
+    public function __construct($event, array $metricConfig = [])
+    {
+        $this->event = $event;
+
+        $this->name = $metricConfig['name'];
+        $this->type = $metricConfig['type'];
+        $this->paramValue = $metricConfig['param_value'] ?? null;
+        $this->configurationTags = $metricConfig['configurationTags'];
+        $this->tags = $metricConfig['tags'];
+
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    /**
+     * DogStatsD FORMAT :
+     * <metric>:<value>|<type>|@<sample rate>|#tag:value,another_tag:another_value
+     *
+     * @throws MetricException
+     */
+    public function toString(): string
+    {
+        return vsprintf('%s:%s|%s%s', [
+            // Required fields
+            $this->getResolvedMetricName(),
+            $this->getMetricsValue(),
+            $this->getMetricType(),
+            // Optional fields
+            $this->getMetricTags(),
+        ]);
+    }
+
+    /**
+     * @throws MetricException
+     */
+    private function getResolvedMetricName(): string
+    {
+        // We don't want to alter the original metric name
+        $resolvedName = $this->name;
+        if (preg_match_all('/<([^>]+)>/', $resolvedName, $placeholders) > 0) {
+            // We want to get all the matching results with the 1st parenthesis in the Regex.
+            // $placeholders[0] will give the entire string with matching pattern
+            // $placeholders[1] will give only matching pattern results: that's what we want
+            if (isset($placeholders[1])) {
+                try {
+                    $resolvedName = $this->resolvePlaceholdersInMetricName($resolvedName, $placeholders[1]);
+                } catch (\Exception $e) {
+                    // We try to throw only MetricExceptions to shut bad configurations exceptions
+                    // We consider that we are supposed to know what we do (professional power).
+                    throw new MetricException($e->getMessage());
+                }
+            }
+        }
+
+        return $resolvedName;
+    }
+
+    private function resolvePlaceholdersInMetricName(string $metricName, array $placeholders)
+    {
+        foreach ($placeholders as $placeholder) {
+            if ($this->event instanceof MonitoringEventInterface) {
+                $value = $this->event->getParameter($placeholder);
+            } else {
+                // Legacy support
+                $value = $this->propertyAccessor->getValue($this->event, $placeholder);
+            }
+            // Replace placeholders with the associated value
+            $metricName = str_replace('<'.$placeholder.'>', $value, $metricName);
+        }
+
+        return $metricName;
+    }
+
+    /**
+     * @throws MetricException
+     */
+    private function getMetricsValue(): float
+    {
+        switch ($this->type) {
+            case 'increment':
+                return 1;
+            case 'decrement':
+                return -1;
+        }
+        if (empty($this->paramValue)) {
+            // This is not allowed anymore for other types than increment and decrement
+            throw new MetricException(
+                \sprintf('The configuration of the event metric "%s" must define the "param_value" option.',
+                    \get_class($this->event))
+            );
+        }
+        if ($this->event instanceof MonitoringEventInterface) {
+            // Using the valid event type, values are now in parameters
+            return $this->event->getParameter($this->paramValue);
+        }
+        if (!\method_exists($this->event, $this->paramValue)) {
+            // Legacy compatibility
+            throw new MetricException(
+                \sprintf('The event class "%s" must have a "%s" method or parameters in order to measure value.',
+                    \get_class($this->event), $this->paramValue)
+            );
+        }
+
+        return \call_user_func([$this->event, $this->paramValue]);
+    }
+
+    /**
+     * @throws MetricException
+     */
+    private function getMetricType(): string
+    {
+        switch ($this->type) {
+            case 'counter':
+            case 'increment':
+            case 'decrement':
+                return self::TYPE_COUNTER;
+            case 'gauge':
+                return self::TYPE_GAUGE;
+            case 'timer':
+                return self::TYPE_TIMER;
+        }
+
+        throw new MetricException('This metric type is not handled');
+    }
+
+    /**
+     * @return string metric labels on format "#label1:value1,label2:value2,label3:value3"
+     */
+    private function getMetricTags(): string
+    {
+        $tags = [];
+
+        // Add global parameters (configured in client or group)
+        if (!empty($this->configurationTags) && is_array($this->configurationTags)) {
+            $tags += $this->configurationTags;
+        }
+        foreach ($this->tags as $tagName) {
+            // Recommended Event type
+            if ($this->event instanceof MonitoringEventInterface) {
+                // If the event is a valid type, we can access custom Tags values
+                if ($this->event->hasParameter($tagName)) {
+                    // Add every metric "tag" parameters, configured in the event metric
+                    $tags[$tagName] = $this->event->getParameter($tagName);
+                }
+            } else {
+                // Legacy support
+                // Try to get the tag value from a function in the event
+                try {
+                    $tags[$tagName] = $this->propertyAccessor->getValue($this->event, $tagName);
+                } catch (\Exception $e) {
+                }
+            }
+        }
+
+        return $this->formatTagsInline($tags);
+    }
+
+    private function formatTagsInline(array $tags): string
+    {
+        $formatLines = array_map(
+            function ($key, $value) {
+                return sprintf('%s:%s', $key, $value);
+            },
+            array_keys($tags),
+            $tags
+        );
+        $inlineTags = implode(',', $formatLines);
+
+        return !empty($inlineTags) ? '|#'.$inlineTags : '';
+    }
+}

--- a/Metric/MetricHandler.php
+++ b/Metric/MetricHandler.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Metric;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Client\ClientInterface;
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
+
+class MetricHandler
+{
+    /** @var int */
+    protected $maxNumberOfMetricToQueue;
+
+    /** @var \SplQueue */
+    private $metrics;
+
+    private $flushMetricsQueue = false;
+
+    /** @var ClientInterface */
+    private $client;
+
+    public function __construct()
+    {
+        $this->initMetricsQueue();
+    }
+
+    public function setClient(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    private function initMetricsQueue()
+    {
+        $this->metrics = new \SplQueue();
+    }
+
+    public function setMetricsQueue(\SplQueue $queue)
+    {
+        $this->metrics = $queue;
+    }
+
+    /**
+     * This function tries to send the metrics according to some rules.
+     * If those rules are not valid, it won't send anything.
+     */
+    public function tryToSendMetrics(): bool
+    {
+        if ($this->hasToSendMetrics()) {
+            return $this->sendMetrics();
+        }
+
+        return false;
+    }
+
+    /**
+     * We define here some rules to force sending the metrics even if we are not required to.
+     *
+     * @return bool
+     */
+    public function hasToSendMetrics(): bool
+    {
+        return $this->isFlushMetricsQueue() || $this->isMaxNumberOfMetricsReached();
+    }
+
+    public function isFlushMetricsQueue(): bool
+    {
+        return $this->flushMetricsQueue;
+    }
+
+    public function setFlushMetricsQueue(bool $flushMetricsQueue): self
+    {
+        $this->flushMetricsQueue = $flushMetricsQueue;
+
+        return $this;
+    }
+
+    public function isMaxNumberOfMetricsReached(): bool
+    {
+        return
+            !empty($this->maxNumberOfMetricToQueue) &&
+            ($this->getMetrics()->count() >= $this->maxNumberOfMetricToQueue);
+    }
+
+    public function getMetrics(): \SplQueue
+    {
+        return $this->metrics;
+    }
+
+    public function sendMetrics(): bool
+    {
+        if ($this->metrics->isEmpty()) {
+            return true;
+        }
+
+        $this->client->sendLines($this->getMetricsAsArray());
+        $this->clearMetricsQueue();
+
+        return true;
+    }
+
+    /**
+     * Format data to send to the server
+     */
+    private function getMetricsAsArray(): array
+    {
+        $metrics = [];
+        foreach ($this->getMetrics() as $metric) {
+            if ($metric instanceof MetricInterface) {
+                try {
+                    $metrics[] = $metric->toString();
+                } catch (MetricException $e) {
+                }
+            }
+        }
+
+        return $metrics;
+    }
+
+    private function clearMetricsQueue(): self
+    {
+        $this->initMetricsQueue();
+
+        return $this;
+    }
+
+    public function addMetricToQueue(MetricInterface $metric): self
+    {
+        $this->metrics->enqueue($metric);
+
+        return $this;
+    }
+
+    public function removeLastMetricFromQueue()
+    {
+        $this->metrics->dequeue();
+    }
+
+    public function setMaxNumberOfMetricToQueue($maxNumberOfMetricToQueue): self
+    {
+        $this->maxNumberOfMetricToQueue = $maxNumberOfMetricToQueue;
+
+        return $this;
+    }
+}

--- a/Metric/MetricInterface.php
+++ b/Metric/MetricInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Metric;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
+
+interface MetricInterface
+{
+    /**
+     * @throws MetricException
+     */
+    public function toString(): string;
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# StatsdTagsBundle
-Statsd Bundle With tags (DataDog Format)
+# StatsdPrometheusBundle
+
+Statsd Bundle for Prometheus. 
+
+:warning: Alpha version 
+
+## Features
+
+* bind any event to increment metrics, set gauges and collect timers
+* send Statsd metrics ([DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) format)
+ compatible with Prometheus 
+(converted with [statsd_exporter](https://github.com/prometheus/statsd_exporter))
+* handle Prometheus tags in the metrics  
+ 
+## Requirements
+
+- Symfony ≥3.4
+- Php ≥7.1
+
+## Set up the bundle
+
+### Installation & configuration
+ 
+* See [Installation](Doc/installation.md) and [Configuration](Doc/configuration.md).
+
+### Usage & examples
+
+* See [Usage](Doc/usage.md) and [Examples](Doc/examples.md).
+
+### Prometheus in Grafana
+
+* See [Prometheus in Grafana](Doc/prometheus-grafana.md) (:warning: Work in progress)
+
+### Contribution & Tests
+
+* See [Contribution & tests](Doc/contribution.md).
+
+## Credits
+
+Bundle provided by the M6Web open source initiative.
+
+our blog : http://tech.m6web.fr/ (french)
+and twitter : https://twitter.com/TechM6Web (french)
+
+## License
+
+StatsdPrometheusBundle is licensed under the [MIT license](LICENCE).

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,0 +1,13 @@
+parameters:
+#    property_accessor.class_statsdtagsprometheusbundle: Symfony\Component\PropertyAccess\PropertyAccessor
+
+services:
+#    property_accessor_statsdtagsprometheusbundle:
+#        public: false
+#        class: "%property_accessor.class_statsdtagsprometheusbundle%"
+#        arguments: [true] # magical => true
+
+
+
+
+

--- a/Resources/views/Collector/statsd.html.twig
+++ b/Resources/views/Collector/statsd.html.twig
@@ -1,0 +1,47 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% set icon %}
+        <img width="28" height="28" alt="Statsd" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wcNDicias3eHAAABSRJREFUSMftlktvG8kVhb/qB5tssvmUGZjU2LAxgT30YvwE5JUWsWPv441/Qrb5F/kVhpHNZOkY8EMTaOWdM0YEBzAGoiyKA1sSSUmWRPaDXY8sKHbkIIMBAsxikNSuG9X33HPuqVMN/1+/9CXu3L2L1vpLz/P+kM8X/J8DRGutjTF/BL53isUS4/H4i6+/vvr7e7+9S5pKECBm/QDmdH//9vzjewyz167r8O23f+Vv3333p1Kp9L3jOA4Av2o2GQwGvHz5klKphOd5NBoNDg4OMGZWsFqtEscxSZIA4Hke+XyeT58+zaCEoFarMRqNSJKEyWTC/fv3OXPmDEophBA4xhiMMWhjCMOQXq9HpVKhVqth2zbj8RghZnwdxyFJEqbTKQBSSqSUhGEIkDU2HA7Z29tjMpkQRRHaaOY4jtYarTXGaCzLwvd9qtUqjUaDarVKLpfLxCoWi0ynU6SUWQO5XI65SgCFQoE0TZFSopTCsiyMNsxxnDk7ow35fJ5KpUIQBBQKhZkEp4pprRFCYNt2JqHW+rM9Qgh8389UWlxcZHt7B61PMTR6RlkIkRVJ05QoikiSJJPK87yscwDbtnEchziOMcZgWRZaa6SUtNttLl26RLlcRiqJMScMM0kxRFHEcDgkTVPiOKZWq2WmMcZ8ZhpjZop0Oh3Onj3L1tYW6+vrSCnRWtPpdNjc3CSKIixh/QdJzWzoc2a2bVMoFJhMJhmg53mEYZgB1mo1Lly4wMePH2k2m1y8eJHDw0N836ff77OyssLDhw9BiBOMuWnUzDRCCJRSxHGMbduEYZg5ECCOY+I4JooigiDg6tWr9Pt9nj17Ri6XY3FxkVu3bjEYDHj+/Dnj8XhmGjPDyBgaozHaUCwWWVhYAKBcLlOpVACYTCbZbF3XJZfLsbS0RC6X4/Xr15RKJQB2d3d58eIFaZpSKBQoFov4vo/RJxinGYLh6OiIbrdLqVTixo0bXL9+nTdv3rCxsUGv1yOfzzMejzl//jz1ep0nT55weHjIcDjMzmqr1WJnZ4fJZIJlWRwfH2Mw/2KolEIqhdYGpRSe57G8vEy1WmVlZQXLslhaWuLy5cuMRiP6/T7Ly8usrq6yvr5OuVzm+Pg4c3gcx4zHY8IwxHXdE7MYpFIopXCkVCglkUrh+z737t0jn8/z+PFjbNtma2uLZrPJ7du36XQ6XLlyhbdv37K6uornebium6WREIIoijg+PiaKInzfPwE8wZAKR6mUVKYomXLt2jX29/d5+vQpSZIQBAHNZhOlFK9eveL9+/e0Wi263S5BEOC6LkIIGo1GJqlSinq9TpqmlEolfN9HKYWUKUqlM0mN0kipePfuHY8ePWJzcxPP8xBC8OHDh+xYSClZW1sjSRIsy6JYLBIEATs7OxnDdrvN9vY20+mUWq02O0LaoOQpSVMpEZZgd3eXXq/HwcEBjuNQrVYZDodZ0gRBwGQy4ejoCIDpdIplWYxGoyzW6vU6o9Eoy9vpdDpLLplJqpBSYrTJsnNufdd18TxvdpucHAnP87JAn8/QdV0sy0IIke2Z15onjJqbRiuFkhJjDO12mwcPHuA4DpZlsbCwwGAwyK6eRqNBGIZEUZTdDL7vs7e3l82w2WwyGo0+y9StrT4ylWilcH5z5w5//uYbr9vt8tVXl7l58+Zn93mr1frJX4hz58796Df7+wdsbLxHCMpra38XArAWv1j8teflf2e0yf1k9f9iOa5rojD8yw8/9P/xc9T/H1//BAUrOqHZypQNAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE1LTA3LTEzVDE0OjM5OjM0KzAyOjAwPShxpQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNS0wNy0xM1QxNDozOTozNCswMjowMEx1yRkAAAAASUVORK5CYII="/>
+    {% endset %}
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Statsd</b>
+            <span>{{ collector.operations }}</span>
+        </div>
+    {% endset %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
+{% endblock %}
+
+{% block head %}
+    {{ parent() }}
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+    <span class="icon">{% spaceless %}
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAEVUlEQVRYhe2Wz0sVaxjHP+/8OOdM53SmOJwgMTtYSHBBTLDFrUjolmvBIxiCFLhI6F5xIbToD3Aj6d3VQgqiRYu6riJaWd3ERUq20pQDSgv1kkiemTMzZ9670JnrHH9gxPXehQ8MM/N93/f5fp8f78wLh3Zo/7GJ4OGXa9cWTPNY9UGQuq5rj/7xwgDQAtA0j1X/Pjx0EPzc+fW3RPCsVQ52dXWRSqWIxWJomkYul2NhYSEcF0Jw6tSpCAaEmJQyxKqrqykUCnieh+M4WJbFyMhIZF0oIFiYTCZZXV0lk8lgGAZCCJLJJIqi/LNI0zh69GjUkaaRSqXCd9/3EUKgqirFYpHl5WWqqqoiXBEBvu+HjtLpNJlMhnQ6jWmaKIqCECLMgGma29IaYIFzKSWpVIpsNouu69i2ja7rEa4dM6AoCpqmoes6mqaFkW917Pt+xEngtBJTFAVd18Or0teOAnK5HJZlcfz4cRKJBKVSiUQiEXG8X8xxHNLpNLquU1VVRXt7O4qi7F2C+fl5bNtmfX2dRCJBNptleXk54ng3bG1tjVKpFMGWlpYwTZN8Ps/Tp0+5efPm3iWQUuI4DrZt4/s+pVKJYrG4LdpKLBaL0d3dzdraGuPj40xNTVEqlfB9n7a2Nt6/f8/09DTxeHzvEgSklmXhed6+BbS0tDA2Nsbi4iJXr17l8uXLzM3NcfLkST5+/MjDhw+pra2NcO1Ygq1R67q+LwGtra3Yts2zZ89QVZU3b95w9uxZWltbmZmZYWRkBCFEhGPXDORyOeLxOIZhoKoqtm1z4sSJiICt2Llz57hw4QJDQ0OcPn06nOM4Do8ePUIIQW1tLcVikZqamt0zIDdVff78mfn5eVKpFFeuXOHWrVuMjo7y6tWrMOozZ84wNzfHkSNH6OnpYXBwEMuyKBQKEaHBPNd1+fbtG47jRLgAws9buaIETU1N5PN5Xr58iWEYDA8P09XVRTKZDEtw+/Zt3r59y8TEBJ7nUSwWI1cwz7IsbNumXC5HuCIZCAZ93+fSpUt0dnbS399PLBZjdnaWx48fc+PGDe7fv8+nT58oFApomsaDBw9wHGfPXgmaORSweY9moFxGSklTUxPd3d309vYyMzODEALHcfjy5QsDAwN0dHRQKBRoaGhgYGCAr1+/RqKtzMD6+jqWZYVbUkoZERCeB36+eFG+eP6clZUV7t69y8rKCqqqUmlSSlzXxXVdDMOI/KR2s4C0vr6ee/fukW9v589370SkBH7ZZ3V1lb6+Pl6/fo0QAiEEjY2NfPjwIeKwsbGR6enpbVjlvPPnzzM5OYmUEikl8Xh8YzuWd+gBr1wmmUyGNQvMdd2we78XC84BWzMhpcTbrQeAfaX0R21rD2wpQTn85zc3N4cT6urqth0+fgTbKMFOAjb35pMnT74vnO+0jfOEhI3s+xqgqaqatWzrr+vXWzL/KvumlX3f1XX9J8/zZg+C79D+3/Y3WY+lvPQgrdQAAAAASUVORK5CYII=" alt="Statsd" />
+        {% endspaceless %}</span>
+    <strong>Statsd</strong>
+    <span class="count">
+        <span>{{ collector.operations }}</span>
+    </span>
+</span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Statsd</h2>
+    {% for clientInfo in collector.clients %}
+        Client : {{ clientInfo.name }}<br />
+        <table class="routing inline">
+            <tr>
+                <th>Metric</th>
+            </tr>
+            {% for operation in clientInfo.operations %}
+                <tr>
+                    <td>{{ operation.message }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endfor %}
+{% endblock %}

--- a/Tests/Client/ServerTest.php
+++ b/Tests/Client/ServerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Tests\Client;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Client\Server;
+use M6Web\Bundle\StatsdPrometheusBundle\Exception\ServerException;
+
+class ServerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetAddressReturnsAddressWhenValidServerConfigIsGiven()
+    {
+        // -- Given --
+        $serverName = 'default';
+        $serverConfig = [
+            'address' => 'udp://address',
+            'port' => 3302,
+        ];
+        $expected = 'udp://address';
+        // -- When --
+        $server = new Server($serverName, $serverConfig);
+        // -- Then --
+        $this->assertEquals($expected, $server->getAddress());
+    }
+
+    public function testGetPortReturnsPortWhenValidServerConfigIsGiven()
+    {
+        // -- Given --
+        $serverName = 'default';
+        $serverConfig = [
+            'address' => 'udp://address',
+            'port' => 3302,
+        ];
+        $expected = 3302;
+        // -- When --
+        $server = new Server($serverName, $serverConfig);
+        // -- Then --
+        $this->assertEquals($expected, $server->getPort());
+    }
+
+    public function testConstructThrowExceptionWhenBadServerConfigIsGiven()
+    {
+        // -- Expects --
+        $this->expectException(ServerException::class);
+        // -- When --
+        new Server('default', [
+            'address' => 'http://address',
+            'port' => 3020,
+        ]);
+    }
+}

--- a/Tests/DependencyInjection/M6WebStatsdPrometheusExtensionTest.php
+++ b/Tests/DependencyInjection/M6WebStatsdPrometheusExtensionTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Tests\DependencyInjection;
+
+use M6Web\Bundle\StatsdPrometheusBundle\DependencyInjection\M6WebStatsdPrometheusExtension;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
+
+class M6WebStatsdPrometheusExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    use \Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+    /** @var ContainerBuilder */
+    private $container;
+
+    /** @var M6WebStatsdPrometheusExtension */
+    private $extension;
+
+    /**
+     * @dataProvider dataProviderForGetServersReturnsExpectation
+     */
+    public function testGetServersReturnsExpectation(array $config, array $expected)
+    {
+        // -- When --
+        $this->extension->load([$config], $this->container);
+        // -- Then --
+        $this->assertEquals($expected, $this->extension->getServers());
+    }
+
+    /**
+     * @dataProvider dataProviderForGetClientsReturnsExpectation
+     */
+    public function testGetClientsReturnsExpectation(array $config, array $expected)
+    {
+        // -- When --
+        $this->extension->load([$config], $this->container);
+        // -- Then --
+        $this->assertEquals($expected, $this->extension->getClients());
+    }
+
+    public function testLoadCorrectTagsConfigurationDoesNoesNotThrowException()
+    {
+        // -- Given --
+        $config = [
+            'tags' => [
+                'tagA' => 'tagAValue',
+                'tagB' => 'tagAValueB',
+            ],
+        ];
+        // -- Expects --
+        // NO exceptions
+        // -- When --
+        $this->extension->load([$config], $this->container);
+    }
+
+    public function testLoadWrongTagsConfigurationDoesThrowsException()
+    {
+        // -- Given --
+        $config = [
+            'tagged' => [
+                ['tagB'],
+            ],
+        ];
+        // -- Expects --
+        $this->expectException(InvalidConfigurationException::class);
+        // -- When --
+        $this->extension->load([$config], $this->container);
+    }
+
+    public function testLoadCorrectYmlConfigurationFileDoesNotThrowException()
+    {
+        // -- Given --
+        $config = Yaml::parseFile(__DIR__.'/../Fixtures/CorrectConfigurationFileTest.yml');
+        // -- Expects --
+        // NO exceptions
+        // -- When --
+        $this->extension->load([$config[M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY]], $this->container);
+    }
+
+    public function testLoadWrongYmlConfigurationFileThrowsException()
+    {
+        // -- Given --
+        $config = Yaml::parseFile(__DIR__.'/../Fixtures/WrongConfigurationFileTest.yml');
+        // -- Expects --
+        $this->expectException(InvalidConfigurationException::class);
+        // -- When --
+        $this->extension->load([$config[M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY]], $this->container);
+    }
+
+    public function dataProviderForGetServersReturnsExpectation(): array
+    {
+        return [
+            'test1' => [
+                // Configuration
+                [
+                    'servers' => [
+                        'default' => [
+                            'address' => 'udp://192.168.1.1',
+                            'port' => 3000,
+                        ],
+                    ],
+                ],
+                // Expected result
+                [
+                    'default' => [
+                        'address' => 'udp://192.168.1.1',
+                        'port' => 3000,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function dataProviderForGetClientsReturnsExpectation()
+    {
+        return [
+            'test1' => [
+                // Configuration (long one)
+                [
+                    'servers' => [
+                        'default' => [
+                            'address' => 'udp://address',
+                            'port' => '3321',
+                        ],
+                    ],
+                    'clients' => [
+                        'default' => [
+                            'server' => 'default',
+                            'groups' => [
+                                'groupA' => [
+                                    'tags' => [
+                                        'tagB' => 'test',
+                                    ],
+                                    'events' => [
+                                        'eventNameA' => [
+                                            'flush_metrics_queue' => true,
+                                            'metrics' => [
+                                                [
+                                                    'type' => 'increment',
+                                                    'name' => 'metricName',
+                                                    'tags' => ['tagA', 'tagB'],
+                                                ],
+                                                [
+                                                    'type' => 'timer',
+                                                    'name' => 'metricName',
+                                                    'tags' => ['tagC', 'tagD'],
+                                                    'param_value' => 'paramValue',
+                                                ],
+                                            ],
+                                        ],
+                                        'eventNameB' => [
+                                            'metrics' => [
+                                                [
+                                                    'type' => 'gauge',
+                                                    'name' => 'metricName',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                'groupB' => [
+                                    'tags' => [
+                                        'tagC' => 'projectName',
+                                    ],
+                                    'events' => [
+                                        'eventNameC' => [
+                                            'metrics' => [
+                                                [
+                                                    'type' => 'counter',
+                                                    'name' => 'metricName',
+                                                    'tags' => ['tagC', 'tagD'],
+                                                ],
+                                            ],
+                                        ],
+                                        'eventNameD' => [
+                                            'flush_metrics_queue' => true,
+                                            'metrics' => [
+                                                [
+                                                    'type' => 'timer',
+                                                    'name' => 'metricName',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                // Expected Clients
+                [
+                    'default' => [
+                        'server' => 'default',
+                        'groups' => [
+                            'groupA' => [
+                                'tags' => [
+                                    'tagB' => 'test',
+                                ],
+                                'events' => [
+                                    'eventNameA' => [
+                                        'flush_metrics_queue' => true,
+                                        'metrics' => [
+                                            [
+                                                'type' => 'increment',
+                                                'name' => 'metricName',
+                                                'tags' => ['tagA', 'tagB'],
+                                            ],
+                                            [
+                                                'type' => 'timer',
+                                                'name' => 'metricName',
+                                                'tags' => ['tagC', 'tagD'],
+                                                'param_value' => 'paramValue',
+                                            ],
+                                        ],
+                                    ],
+                                    'eventNameB' => [
+                                        'flush_metrics_queue' => false,
+                                        'metrics' => [
+                                            [
+                                                'type' => 'gauge',
+                                                'name' => 'metricName',
+                                                'tags' => [],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'groupB' => [
+                                'tags' => [
+                                    'tagC' => 'projectName',
+                                ],
+                                'events' => [
+                                    'eventNameC' => [
+                                        'flush_metrics_queue' => false,
+                                        'metrics' => [
+                                            [
+                                                'type' => 'counter',
+                                                'name' => 'metricName',
+                                                'tags' => ['tagC', 'tagD'],
+                                            ],
+                                        ],
+                                    ],
+                                    'eventNameD' => [
+                                        'flush_metrics_queue' => true,
+                                        'metrics' => [
+                                            [
+                                                'type' => 'timer',
+                                                'name' => 'metricName',
+                                                'tags' => [],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container = new ContainerBuilder();
+        $this->extension = new M6WebStatsdPrometheusExtension();
+    }
+}

--- a/Tests/Fixtures/CorrectConfigurationFileTest.yml
+++ b/Tests/Fixtures/CorrectConfigurationFileTest.yml
@@ -1,0 +1,304 @@
+m6web_statsd_prometheus:
+
+    servers:
+        default:
+            address: 'udp://%statsd.address%'
+            port: '%statsd.port%'
+        local:
+            address: 'udp://127.0.0.1'
+            port: 9125
+
+    tags:
+        project: 'service_6play_users'
+
+    # Clients definition
+    clients:
+
+        # Default client
+        default:
+            server: 'local'
+            groups:
+
+                # Default group
+                default:
+                    events:
+
+                        uniqu_anonymous_id:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'uniqanonymousid'
+                                    tags:
+                                        - 'platform'
+
+                        m6kernel.terminate:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'request'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'statusCode'
+                                        - 'routeName'
+
+                                -   type: 'timer'
+                                    name: 'memory'
+                                    param_value: 'getMemory'
+                                    tags:
+                                        - 'statusCode'
+                                        - 'routeName'
+
+                        m6web.console.command:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.run'
+                                    tags:
+                                        - 'underscoredCommandName'
+
+                        m6web.console.exception:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.exception'
+                                    tags:
+                                        - 'underscoredCommandName'
+
+                        m6web.console.terminate:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'command.exception'
+                                    param_value: 'executionTimeHumanReadable'
+                                    tags:
+                                        - 'underscoredCommandName'
+
+                        m6kernel.exception:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'errors'
+                                    tags:
+                                        - 'statusCode'
+
+                        m6video.user_box.pairing:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'user_box'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'status'
+
+                        m6video.auto_pairing:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'auto_pairing'
+                                    tags:
+                                        - 'network'
+                                        - 'status'
+
+                        m6video.redis.list.size:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'command.redis.list.size'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+
+                        m6video.command.clean_deleted_tests:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.clean_deleted_tests'
+                                    tags:
+                                        - 'value'
+
+                        m6video.command.export_user_data.send.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.export_user_data.send.error'
+                                    tags:
+                                        - 'customer'
+
+                        m6video.command.client.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.send.error'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+                                        - 'value'
+
+                        m6video.command.redis.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.redis.error'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+
+                        m6video.command.import_user_data.client.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command.import_user_data.error'
+                                    tags:
+                                        - 'value'
+
+                        m6video.command:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'command'
+                                    tags:
+                                        - 'customer'
+                                        - 'command'
+                                        - 'value'
+
+                        m6video.krux.segments.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'krux.segments.error'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'value'
+
+                        m6video.sms.send:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'sms'
+                                    tags:
+                                        - 'provider'
+                                        - 'type'
+                                        - 'success'
+                                        - 'code'
+
+                        m6video.krux.call:
+                            metrics:
+                                # increment: krux.call.<route>.<platformCode>.<value>
+                                -   type: 'timer'
+                                    name: 'krux.call'
+                                    param_value: 'geTiming'
+                                    tags:
+                                        - 'route'
+                                        - 'platformCode'
+                                        - 'value'
+
+                        m6video.gigya.notifications:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'gigya.notifications'
+                                    tags:
+                                        - 'value'
+
+                        m6video.store.request:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'store.validation'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+                                        - 'statusCode'
+
+                        m6video.store.validation.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'store.validation.error'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+                                        - 'value'
+
+                        m6video.store.validation.success:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'store.validation.success'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+
+                        m6video.store.freemium_pack.active:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'store.freemium_pack'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'storeCode'
+                                        - 'active'
+
+                        m6video.import.status:
+                            flush_metrics_queue: true
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'import'
+                                    tags:
+                                        - 'keyspace'
+                                        - 'table'
+                                        - 'status'
+
+                        applaunch.client.error:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'applaunch.server.error'
+
+                        applaunch.client.success:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'applaunch.server.success'
+
+                        m6video.mindbaz.export:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'mindbaz.export'
+                                    tags:
+                                        - 'type'
+                                        - 'value'
+
+                        m6video.client.release:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'client.release'
+                                    tags:
+                                        - 'platformCode'
+                                        - 'release'
+
+                        m6video.user.delete:
+                            metrics:
+                                -   type: 'increment'
+                                    name: 'user.delete'
+                                    tags:
+                                        - 'value'
+
+                        m6web.cassandra:
+                            metrics:
+                                -   type: 'timer'
+                                    name: 'cassandra.all_keyspaces'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'command'
+
+                        redis.command:
+                            metrics:
+                                # increment: cache.redis.composant.<command>.service-6play-users
+                                -   type: 'timer'
+                                    name: 'cache.redis.composant'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'command'
+
+                        daemon.loop.iteration:
+                            metrics:
+                                # increment: worker.service-6play-users.<command>.iteration
+                                -   type: 'timer'
+                                    name: 'worker.iteration'
+                                    param_value: 'getTiming'
+                                    tags:
+                                        - 'command'
+
+                                -   type: 'timer'
+                                    name: 'memory.worker.iteration'
+                                    param_value: 'getMemory'
+                                    tags:
+                                        - 'command'
+
+                        daemon.stop:
+                            flush_metrics_queue: true
+
+                        daemon.iteration.statsd.immediatesend:
+                            flush_metrics_queue: true

--- a/Tests/Fixtures/CustomEventTest.php
+++ b/Tests/Fixtures/CustomEventTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Fixtures;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class CustomEventTest extends Event
+{
+    private $value;
+    private $placeHolder1;
+    private $placeHolder2;
+
+    public function __construct($value, $placeHolder1 = null, $placeHolder2 = null)
+    {
+        $this->value = $value;
+        $this->placeHolder1 = $placeHolder1;
+        $this->placeHolder2 = $placeHolder2;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPlaceHolder1()
+    {
+        return $this->placeHolder1;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPlaceHolder2()
+    {
+        return $this->placeHolder2;
+    }
+}

--- a/Tests/Fixtures/WrongConfigurationFileTest.yml
+++ b/Tests/Fixtures/WrongConfigurationFileTest.yml
@@ -1,0 +1,27 @@
+m6web_statsd_prometheus:
+    servers:
+        default:
+            address: 'udp://%statsd_tags.address%'
+            port: '%statsd_tags.port%'
+    tags:
+        tagA: 'tagValue1'
+        tagB: 'tagValue2'
+
+    clients:
+        default:
+            servers: ['all']
+            grousp:
+                groupA:
+                    eventss: #events types
+                        m6kernel.terminate1:
+                            theMetrics:
+                                -
+                                    type: 'increment'
+                                    wrongName: 'status.code.<code>'
+                                    tags: #tags only for current event
+                                        - 'tag1Event2'
+                                        - 'tag2'
+                                -
+                                    type: 'timser'
+                                    metric: 'status.code.timing'
+                                    custom_param: 'customTiming'

--- a/Tests/Listener/EventListenerTest.php
+++ b/Tests/Listener/EventListenerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Tests\Client;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Listener\EventListener;
+use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEvent;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\MetricHandler;
+
+class EventListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetFlushMetricsQueueIsAlwaysCalledWhenHandledEventIsSentInHandleEvent()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $eventConfig = [
+            'flush_metrics_queue' => false,
+            'metrics' => [
+                [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+            ],
+        ];
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock)
+            ->addEventToListen($eventName, $eventConfig);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->once())
+            ->method('setFlushMetricsQueue');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testSetFlushMetricsQueueIsNotCalledWhenNotHandledEventIsSentInHandleEvent()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->never())
+            ->method('setFlushMetricsQueue');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testAddMetricToQueueFunctionIsCalledOnceWhenHandledEventWithOneMetricIsSentInHandleEventFunction()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $eventConfig = [
+            'flush_metrics_queue' => false,
+            'metrics' => [
+                [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+            ],
+        ];
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock)
+            ->addEventToListen($eventName, $eventConfig);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->once())
+            ->method('addMetricToQueue');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testAddMetricToQueueFunctionIsCalledTwiceWhenHandledEventWithTwoMetricsIsSentInHandleEventFunction()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $eventConfig = [
+            'flush_metrics_queue' => false,
+            'metrics' => [
+                [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                [
+                    'type' => 'counter',
+                    'name' => 'http.status.200',
+                    'param_value' => 'counter',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+            ],
+        ];
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock)
+            ->addEventToListen($eventName, $eventConfig);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->exactly(2))
+            ->method('addMetricToQueue');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testAddMetricToQueueFunctionIsNotCalledTwiceWhenHandledEventWithNoMetricIsSentInHandleEventFunction()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $eventConfig = [
+            'flush_metrics_queue' => false,
+            'metrics' => [],
+        ];
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock)
+            ->addEventToListen($eventName, $eventConfig);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->never())
+            ->method('addMetricToQueue');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testAddMetricToQueueFunctionIsNotCalledTwiceWhenNotHandledEventIsSentInHandleEventFunction()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->never())
+            ->method('addMetricToQueue');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testTryToSendMetricsFunctionIsCalledOnceWhenHandledEventIsSent()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $eventConfig = [
+            'flush_metrics_queue' => false,
+            'metrics' => [
+                [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+            ],
+        ];
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock)
+            ->addEventToListen($eventName, $eventConfig);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->once())
+            ->method('tryToSendMetrics');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    public function testTryToSendMetricsFunctionIsNotCalledOnceWhenNotHandledEventIsSent()
+    {
+        // -- Given --
+        $monitoringEvent = new MonitoringEvent();
+        $eventName = 'http_status_listener';
+        $metricHandlerMock = $this->getMetricHandlerMock();
+        $eventListener = $this->getEventListenerObject($metricHandlerMock);
+        // -- Expects --
+        $metricHandlerMock
+            ->expects($this->never())
+            ->method('tryToSendMetrics');
+        // -- When --
+        $eventListener->handleEvent($monitoringEvent, $eventName);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getMetricHandlerMock()
+    {
+        return $this->createMock(MetricHandler::class);
+    }
+
+    private function getEventListenerObject($metricHandler): EventListener
+    {
+        return (new EventListener())
+            ->setMetricHandler($metricHandler);
+    }
+}

--- a/Tests/Metric/MetricHandlerTest.php
+++ b/Tests/Metric/MetricHandlerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Test\Metric;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Client\UdpClient;
+use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEvent;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\Metric;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\MetricHandler;
+
+class MetricHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetMetricsReturnsExpectedWhenAddMetric()
+    {
+        // -- Given --
+        $metricHandler = $this->getMetricHandlerObject();
+        $metric = new Metric(new MonitoringEvent(), [
+            'name' => 'myMetricName',
+            'type' => 'increment',
+            'configurationTags' => [],
+            'tags' => [],
+        ]);
+        $expected = new \SplQueue();
+        $expected->enqueue(
+            (new Metric(new MonitoringEvent(), [
+                'name' => 'myMetricName',
+                'type' => 'increment',
+                'configurationTags' => [],
+                'tags' => [],
+            ]))
+        );
+        // -- When --
+        $metricHandler->addMetricToQueue($metric);
+        // -- Then --
+        $this->assertEquals($expected, $metricHandler->getMetrics());
+    }
+
+    public function testIsFlushMetricsQueueReturnsFalseByDefault()
+    {
+        // -- Given --
+        $metricHandler = $this->getMetricHandlerObject();
+        // -- When --
+        $isFlushMetricsQueue = $metricHandler->isFlushMetricsQueue();
+        // -- Then --
+        $this->assertFalse($isFlushMetricsQueue);
+    }
+
+    public function testIsFlushMetricsQueueReturnsTrueWhenSetFlushMetricsQueueToTrue()
+    {
+        // -- Given --
+        $metricHandler = $this->getMetricHandlerObject();
+        // -- When --
+        $metricHandler->setFlushMetricsQueue(true);
+        // -- Then --
+        $this->assertTrue($metricHandler->isFlushMetricsQueue());
+    }
+
+    public function testTryToSendMetricsReturnsFalseWhenFlushMetricsQueueIsFalse()
+    {
+        // -- Given --
+        $metricHandler = $this->getMetricHandlerObject();
+        // -- When --
+        $metricHandler->setFlushMetricsQueue(false);
+        // -- Then --
+        $this->assertFalse($metricHandler->tryToSendMetrics());
+    }
+
+    public function testTryToSendMetricsReturnsTrueWhenFlushMetricsQueueIsTrue()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(false);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setFlushMetricsQueue(true);
+        // -- Then --
+        $this->assertTrue($metricHandler->tryToSendMetrics());
+    }
+
+    public function testClientSendLinesIsCalledWhenFlushMetricsQueueIsTrueAndQueueNotEmpty()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(false);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        $metricHandler->setFlushMetricsQueue(true);
+        // -- Expects --
+        $client->expects($this->once())
+            ->method('sendLines');
+        // -- When --
+        $metricHandler->tryToSendMetrics();
+    }
+
+    public function testClientSendLinesIsNotCalledWhenFlushMetricsQueueIsTrueAndQueueIsEmpty()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(true);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        $metricHandler->setFlushMetricsQueue(true);
+        // -- Expects --
+        $client->expects($this->never())
+            ->method('sendLines');
+        // -- When --
+        $metricHandler->tryToSendMetrics();
+    }
+
+    public function testClientSendLinesIsNotCalledWhenFlushMetricsQueueIsFalse()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(false);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        $metricHandler->setFlushMetricsQueue(false);
+        // -- Expects --
+        $client->expects($this->never())
+            ->method('sendLines');
+        // -- When --
+        $metricHandler->tryToSendMetrics();
+    }
+
+    public function testClientSendLinesIsNotCalledWhenFlushMetricsQueueIsFalseAndMaxNumberNotReached()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(true, 1); // A queue with 1 element
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        $metricHandler->setFlushMetricsQueue(false);
+        $metricHandler->setMaxNumberOfMetricToQueue(2); // A limit at 2 elements
+        // -- Expects --
+        $client->expects($this->never())
+            ->method('sendLines');
+        // -- When --
+        $metricHandler->tryToSendMetrics();
+    }
+
+    public function testIsMaxNumberReachedReturnsTrueWhenMaxNumberIsReached()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(true, 10);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setMaxNumberOfMetricToQueue(5);
+        // -- Then --
+        $this->assertTrue($metricHandler->isMaxNumberOfMetricsReached());
+    }
+
+    public function testIsMaxNumberReachedReturnsFalseWhenMaxNumberIsNotReached()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(true, 10);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setMaxNumberOfMetricToQueue(15);
+        // -- Then --
+        $this->assertFalse($metricHandler->isMaxNumberOfMetricsReached());
+    }
+
+    public function testHasToSendMetricsReturnsTrueWhenMaxNumberIsReached()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(true, 10);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setMaxNumberOfMetricToQueue(5);
+        // -- Then --
+        $this->assertTrue($metricHandler->hasToSendMetrics());
+    }
+
+    public function testHasToSendMetricsReturnsFalseWhenMaxNumberIsNotReached()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(true, 10);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setMaxNumberOfMetricToQueue(15);
+        // -- Then --
+        $this->assertFalse($metricHandler->hasToSendMetrics());
+    }
+
+    public function testHasToSendMetricsReturnsTrueWhenFlushMetricsQueueIsTrue()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(false);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setFlushMetricsQueue(true);
+        // -- Then --
+        $this->assertTrue($metricHandler->hasToSendMetrics());
+    }
+
+    public function testHasToSendMetricsReturnsFalseWhenFlushMetricsQueueIsFalse()
+    {
+        // -- Given --
+        $client = $this->getUdpClientMock();
+        $metricsQueue = $this->getMetricsQueueMock(false);
+        $metricHandler = $this->getMetricHandlerObject($client, $metricsQueue);
+        // -- When --
+        $metricHandler->setFlushMetricsQueue(false);
+        // -- Then --
+        $this->assertFalse($metricHandler->hasToSendMetrics());
+    }
+
+    protected function getMetricHandlerObject($client = null, $metricsQueue = null)
+    {
+        $metricHandler = new MetricHandler();
+        if ($client) {
+            $metricHandler->setClient($client);
+        }
+        if ($metricsQueue) {
+            $metricHandler->setMetricsQueue($metricsQueue);
+        }
+
+        return $metricHandler;
+    }
+
+    private function getMetricsQueueMock(bool $isEmpty, int $count = 0)
+    {
+        $metricsQueue = $this->createMock(\SplQueue::class);
+        $metricsQueue->method('isEmpty')
+            ->willReturn($isEmpty);
+        $metricsQueue->method('count')
+            ->willReturn($count);
+
+        return $metricsQueue;
+    }
+
+    private function getUdpClientMock()
+    {
+        return $this->createMock(UdpClient::class);
+    }
+}

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Tests\Metric;
+
+use Fixtures\CustomEventTest;
+use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEvent;
+use M6Web\Bundle\StatsdPrometheusBundle\Metric\Metric;
+use Symfony\Component\EventDispatcher\Event;
+
+class MetricTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getDataEvents
+     */
+    public function testToStringWithEventReturnsExpected(
+        Event $event, array $metricConfig, string $expectedResult
+    ) {
+        // -- Given --
+        $metric = new Metric($event, $metricConfig);
+        // -- Then --
+        $this->assertSame($expectedResult, $metric->toString());
+    }
+
+    /**
+     * @dataProvider getDataMonitorableEvents
+     */
+    public function testToStringWithMonitorableEventReturnsExpected(
+        Event $event, array $metricConfig, string $expectedResult
+    ) {
+        // -- Given --
+        $metric = new Metric($event, $metricConfig);
+        // -- Then --
+        $this->assertSame($expectedResult, $metric->toString());
+    }
+
+    /**
+     * @dataProvider getDataLegacyEvents
+     */
+    public function testToStringWithLegacyEventReturnsExpected(
+        Event $event, array $metricConfig, string $expectedResult
+    ) {
+        // -- Given --
+        $metric = new Metric($event, $metricConfig);
+        // -- Then --
+        $this->assertSame($expectedResult, $metric->toString());
+    }
+
+    public function testSendCounterEventWithNoParamValueThrowsException()
+    {
+        // -- Given --
+        $event = new Event();
+        $metricConfig = [
+            'type' => 'counter',
+            'name' => 'http.status.200',
+            'configurationTags' => [],
+            'tags' => [],
+        ];
+        $metric = new Metric($event, $metricConfig);
+        // -- Expects --
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The configuration of the event metric '
+            .'"Symfony\Component\EventDispatcher\Event" must define the "param_value" option');
+        // -- When --
+        $metric->toString();
+    }
+
+    public function testSendCounterEventWithNoDefinedFunctionValueThrowsException()
+    {
+        // -- Given --
+        $event = new Event();
+        $metricConfig = [
+            'type' => 'counter',
+            'name' => 'http.status.200',
+            'param_value' => 'notDefinedFunction',
+            'configurationTags' => [],
+            'tags' => [],
+        ];
+        $metric = new Metric($event, $metricConfig);
+        // -- Expects --
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The event class "Symfony\Component\EventDispatcher\Event" '
+            .'must have a "notDefinedFunction" method or parameters in order to measure value.');
+        // -- When --
+        $metric->toString();
+    }
+
+    public function getDataEvents()
+    {
+        return [
+            // Increment: object Event (no tags)
+            'test0' => [
+                'event' => (new Event()),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                // Only the metric, type and value are returned
+                'expectedResult' => 'http.status.200:1|c',
+            ],
+            // Increment: object Event (With tags)
+            'test1' => [
+                'event' => (new Event()),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [
+                        // This corresponds to a tag defined in the config (client or group config)
+                        'project' => 'service-6play-users',
+                    ],
+                    'tags' => [
+                        // these ones with no value corresponds to events tags. they're values have to
+                        // be specified in the event object
+                        'country',
+                        'platform',
+                    ],
+                ],
+                // Only the metric name, type, value and configurationTags are returned
+                // The custom metric tags are ignored because, the object does not instantiate MonitoringEventInterface
+                'expectedResult' => 'http.status.200:1|c|#project:service-6play-users',
+            ],
+        ];
+    }
+
+    public function getDataMonitorableEvents()
+    {
+        return [
+            // Increment: object MonitoringEvent (no tags)
+            'test0' => [
+                'event' => (new MonitoringEvent()),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'http.status.200',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                'expectedResult' => 'http.status.200:1|c',
+            ],
+            // Increment: object MonitoringEvent (With tags)
+            'test1' => [
+                'event' => (new MonitoringEvent([
+                    // This param return the metric value
+                    'counterValue' => 124,
+                    // Those metric tags values are specified when we send the event
+                    'country' => 'France',
+                    'platform' => 'm6web',
+                ])),
+                'eventConfig' => [
+                    'type' => 'counter',
+                    'name' => 'http.status.200',
+                    'param_value' => 'counterValue',
+                    'configurationTags' => [
+                        // This corresponds to a tag defined in the config (client or group config)
+                        'project' => 'service-6play-users',
+                    ],
+                    'tags' => [
+                        // these ones with no value corresponds to events tags. they're values have to
+                        // be specified in the event object
+                        'country',
+                        'platform',
+                    ],
+                ],
+                // We are supposed to have all the metric data and every defined tags
+                'expectedResult' => 'http.status.200:124|c|#project:service-6play-users,country:France,platform:m6web',
+            ],
+            // Counter with custom param: object MonitoringEvent (no tags)
+            'test2' => [
+                'event' => (new MonitoringEvent([
+                    'getCustomParam' => 32546,
+                ])),
+                'eventConfig' => [
+                    'type' => 'counter',
+                    'name' => 'specific_sql_query',
+                    'param_value' => 'getCustomParam',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                // We are supposed to get the metric name, type and the custom parameter value
+                'expectedResult' => 'specific_sql_query:32546|c',
+            ],
+            // Counter with custom param: object MonitoringEvent (With tags)
+            'test3' => [
+                'event' => (new MonitoringEvent([
+                    'getCustomParam' => 12456,
+                    'project' => 'service-6play-users',
+                    'country' => 'France',
+                    'platform' => 'm6web',
+                ])),
+                'eventConfig' => [
+                    'type' => 'counter',
+                    'name' => 'specific_sql_query',
+                    'param_value' => 'getCustomParam',
+                    'configurationTags' => [
+                        'project' => 'service-6play-users-cloud',
+                    ],
+                    'tags' => ['country', 'platform'],
+                ],
+                // We are supposed to get the metric name, type, the custom parameter value and all the tags
+                'expectedResult' => 'specific_sql_query:12456|c|#project:service-6play-users-cloud,country:France,platform:m6web',
+            ],
+            // Increment with dynamic metric name (no tags)
+            'test4' => [
+                'event' => (new MonitoringEvent([
+                    'myFirstPlaceHolder' => 'myPlaceHolderValue',
+                ])),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'specific_sql_query.<myFirstPlaceHolder>',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                // We are supposed to get the metric name, type, the custom parameter value and all the tags
+                'expectedResult' => 'specific_sql_query.myPlaceHolderValue:1|c',
+            ],
+            // Increment with multiple dynamic metric name with multiple placeholders (With tags) => COMBO
+            'test+INFINITY' => [
+                'event' => (new MonitoringEvent([
+                    'myFirstPlaceHolder' => 'firstPlaceHolderValue',
+                    'mySecondPlaceHolder' => 'secondPlaceHolderValue',
+                ])),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'specific_sql_query.http',
+                    'configurationTags' => [
+                        'project' => 'service-6play-users-cloud',
+                    ],
+                    'tags' => ['country', 'platform', 'myFirstPlaceHolder', 'mySecondPlaceHolder'],
+                ],
+                // We are supposed to get the metric name, type, the custom parameter value and all the tags
+                'expectedResult' => 'specific_sql_query.http:1|c|#project:service-6play-users-cloud,myFirstPlaceHolder:firstPlaceHolderValue,mySecondPlaceHolder:secondPlaceHolderValue',
+            ],
+        ];
+    }
+
+    public function getDataLegacyEvents()
+    {
+        return [
+            // Counter with custom param: object CustomEvent (no tags) => Legacy compatibility
+            'test0' => [
+                'event' => (new CustomEventTest(12)),
+                'eventConfig' => [
+                    'type' => 'counter',
+                    'name' => 'specific_sql_query',
+                    'param_value' => 'getValue', // Legacy support <3
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                // We have the metric name, type and the custom value
+                'expectedResult' => 'specific_sql_query:12|c',
+            ],
+            // Counter with custom param: object Event (With tags)
+            'test1' => [
+                'event' => (new CustomEventTest(12)),
+                'eventConfig' => [
+                    'type' => 'counter',
+                    'name' => 'specific_sql_query',
+                    'param_value' => 'getValue',
+                    'configurationTags' => [
+                        'project' => 'service-6play-users-cloud',
+                    ],
+                    'tags' => ['country', 'platform'],
+                ],
+                // Only the metric name, type, value and configurationTags are returned
+                // The custom metric tags are ignored because, the object does not instantiate MonitoringEventInterface
+                'expectedResult' => 'specific_sql_query:12|c|#project:service-6play-users-cloud',
+            ],
+            // Increment with dynamic metric name (no tags)
+            'test2' => [
+                'event' => (new CustomEventTest(12, 'placeHolder1Value')),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'specific_sql_query.<placeHolder1>',
+                    'configurationTags' => [],
+                    'tags' => [],
+                ],
+                // We are supposed to get the metric name, type, the custom parameter value and all the tags
+                'expectedResult' => 'specific_sql_query.placeHolder1Value:1|c',
+            ],
+            // Increment with multiple dynamic metric name with multiple placeholders (With tags) => COMBO
+            'test3' => [
+                'event' => (new CustomEventTest(null, 'placeHolder1Value', 'placeHolder2Value')),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'specific_sql_query.<placeHolder1>.http.<placeHolder2>',
+                    'configurationTags' => [
+                        'project' => 'service-6play-users-cloud',
+                    ],
+                    'tags' => ['country', 'platform'],
+                ],
+                // We are supposed to get the metric name, type, the custom parameter value and all the tags
+                'expectedResult' => 'specific_sql_query.placeHolder1Value.http.placeHolder2Value:1|c|#project:service-6play-users-cloud',
+            ],
+            // Increment with multiple tags sent with custom event (with property accessors)
+            'test4' => [
+                'event' => (new CustomEventTest(null, 'placeHolder1Value', 'placeHolder2Value')),
+                'eventConfig' => [
+                    'type' => 'increment',
+                    'name' => 'specific_sql_query_http',
+                    'configurationTags' => [
+                        'project' => 'service-6play-users-cloud',
+                    ],
+                    'tags' => [
+                        'country',
+                        'platform',
+                        'placeHolder1',
+                        'placeHolder2',
+                    ],
+                ],
+                // We are supposed to get the metric name, type, the custom parameter value and all the tags
+                'expectedResult' => 'specific_sql_query_http:1|c|#project:service-6play-users-cloud,placeHolder1:placeHolder1Value,placeHolder2:placeHolder2Value',
+            ],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "m6web/statsd-prometheus-bundle",
+    "description": "Add statsd metrics in your symfony app. Allow you to bind metrics on any symfony event.",
+    "type": "symfony-bundle",
+    "license": "MIT",
+    "keywords": ["symfony", "bundle", "statsd", "m6web"],
+    "authors": [
+        {
+            "name": "M6Web",
+            "email": "opensource@m6web.fr",
+            "homepage": "https://tech.m6web.fr/"
+        }
+    ],
+    "config": {
+        "bin-dir": "bin",
+        "vendor-dir": "vendor"
+    },
+    "require": {
+        "php": "^7.1",
+        "symfony/property-access": "^3.4 || ^4.0"
+    },
+    "require-dev": {
+        "m6web/php-cs-fixer-config": "^1.0",
+        "symfony/symfony": "^3.4 || ^4.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0",
+        "symfony/var-dumper": "^4.1"
+    },
+    "autoload": {
+        "psr-4": { "M6Web\\Bundle\\StatsdPrometheusBundle\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="StatsdPrometheusBundle Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
## Why?
Init bundle to send metrics to prometheus in UDP.

## How?
By redeveloping the Stasd Bundle and adding the Prometheus tags in it.

## US
https://m6web.tpondemand.com/entity/55185-service-users-metrics-prometheus

## Tests on Service-6play-users

### Temporary PR
* PR : https://github.m6web.fr/Replay/service-6play-users/pull/610
* Recipe : http://ci-temp-prometheus-bundle-test.recette.6play-users.6play.fr/ 

### Graphs
* Check preprod metrics here: http://m6w-pp-prometheus-01.m6web.fr:9090/graph
* Preprod Grafana here: https://preprod-grafana.m6web.fr/d/000000115/service-6play-users

## Todo
* [x] Load the configuration
* [x] Define the PrometheusEventListener main handler
* [x] Define the new MonitorableEvent class
* [x] Define the new Metric class to format Prometheus message format
* [x] Define the new MetricHandler
* [x] Set the new UDP Client
* [x] Install the bundle to a project (6play-users)
* [x] Test UDP local
* [x] Test Statsd-exporter server local
* [x] Test UDP preprod
    * [x] Test recipe
    * [x] Get metrics in preprod Grafana
* [x] Verify the documentation
* [x] Verify the unit tests