### PR TITLE
remove constructor in monitoring event interface

### DIFF
--- a/Event/MonitoringEvent.php
+++ b/Event/MonitoringEvent.php
@@ -9,6 +9,13 @@ class MonitoringEvent extends Event implements MonitoringEventInterface
     /** @var array */
     private $parameters;
 
+    /**
+     * MonitoringEvent constructor.
+     *
+     * @param array $parameters parameters can contain metrics values, tags values or/and custom param values
+     *
+     * @see https://github.com/M6Web/StatsdPrometheusBundle/blob/master/Doc/usage.md
+     */
     public function __construct(array $parameters = [])
     {
         $this->parameters = $parameters;

--- a/Event/MonitoringEventInterface.php
+++ b/Event/MonitoringEventInterface.php
@@ -4,15 +4,6 @@ namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
 
 interface MonitoringEventInterface
 {
-    /**
-     * MonitoringEvent constructor.
-     *
-     * @param array $parameters parameters can contains metrics values, tags values or/and custom param values
-     *
-     * @see https://github.com/M6Web/StatsdPrometheusBundle/blob/master/Doc/usage.md
-     */
-    public function __construct(array $parameters = []);
-
     public function hasParameter(string $key): bool;
 
     /**


### PR DESCRIPTION
## Why?
As a developer, I would like to handle my events with custom classes and different constructors, implementing MonitoringEventInterface.

## How?
By removing the constructor in MonitoringEventInterface
