### PR TITLE
Feat: Add a metrics section on top, with a prefix scalar node.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,12 +23,24 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root($this->configurationRootKey);
 
+        $this->addMetricsSection($rootNode);
         $this->addServersSection($rootNode);
         $this->addClientsSection($rootNode);
         $this->addTagsSection($rootNode);
         $this->addDefaultEventSection($rootNode);
 
         return $treeBuilder;
+    }
+
+    private function addMetricsSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('metrics')
+                    ->children()
+                        ->scalarNode('prefix')->end()
+                    ->end()
+            ->end();
     }
 
     private function addServersSection(ArrayNodeDefinition $rootNode): void

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -23,6 +23,9 @@ class M6WebStatsdPrometheusExtension extends Extension
     /** @var ContainerBuilder */
     private $container;
 
+    /** @var string */
+    private $metricsPrefix = '';
+
     /** @var array */
     private $clientServiceIds = [];
 
@@ -45,6 +48,7 @@ class M6WebStatsdPrometheusExtension extends Extension
         $configuration = new Configuration(self::CONFIG_ROOT_KEY);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $this->metricsPrefix = $config['metrics']['prefix'] ?? '';
         $this->servers = $config['servers'] ?? [];
         $this->clients = $config['clients'] ?? [];
         $this->tags = $config['tags'] ?? [];
@@ -138,6 +142,8 @@ class M6WebStatsdPrometheusExtension extends Extension
                         $tagsConfig,
                         $eventsGroupConfig['tags'] ?? []
                     );
+                    // Prefix the metric name.
+                    $metricConfig['name'] = $this->metricsPrefix.$metricConfig['name'];
                 }
                 // Set all the metrics config array n the object
                 // One event can send several metrics. Multiple metrics will be handled in the Listener manager.

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -38,14 +38,19 @@ class M6WebStatsdPrometheusExtension extends Extension
     /** @var array */
     private $tags;
 
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration(self::CONFIG_ROOT_KEY);
+    }
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $this->container = $container;
 
-        $loader = (new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config')));
+        $loader = (new Loader\YamlFileLoader($this->container, new FileLocator(__DIR__.'/../Resources/config')));
         $loader->load('services.yml');
 
-        $configuration = new Configuration(self::CONFIG_ROOT_KEY);
+        $configuration = $this->getConfiguration($configs, $this->container);
         $config = $this->processConfiguration($configuration, $configs);
 
         $this->metricsPrefix = $config['metrics']['prefix'] ?? '';

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -184,6 +184,17 @@ See [5. Configure the metrics](#5-configure-the-metrics).
 
 ## 5. Configure the metrics
 
+### Global prefix
+
+You can set a global prefix that will be prepend to every metrics created.
+It is useful when sharing your prometheus storage with multiple organizations.
+
+```yaml
+m6web_statsd_prometheus:
+    metrics: 
+        prefix: 'myorganization_'
+```
+
 ### Description
 
 This is the main structure you need to use.
@@ -221,6 +232,9 @@ This is the metric type.
 __counter, gauge, increment, decrement, timer__ 
 
 * `name`: string
+
+__Reminder__: The name of all your metrics will be prefixed by the value of `m6web_statsd_prometheus.metrics.prefix`.
+By default none.
 
 * `param_value`: string
 


### PR DESCRIPTION
## Why?
We want to be able to prefix every metrics name with the same value.

## How?
Add a new top level section named `metrics` with only one child named `prefix`.

## Todo
* [ ] How the fuck do we test it? :cactus: 
* [x] @fabdsp Add a WIP label on this project?