### PR TITLE
Feat: Add a suggest for `m6web/http-kernel-bundle` and update the doc.

### DIFF
--- a/Doc/prometheus-grafana.md
+++ b/Doc/prometheus-grafana.md
@@ -10,6 +10,8 @@ Getting started with Prometheus
 
 This is a configuration example that we will use for this documentation:
 
+**Note**: You will need to add the `m6web/http-kernel-bundle` to listen to the `m6kernel.terminate` and get the timing from the event. 
+
 ```yaml
 m6web_statsd_prometheus:
     servers: [...]

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
+    },
+    "suggest": {
+        "m6web/http-kernel-bundle": "Add the timing to the kernel terminate event."
     }
 }


### PR DESCRIPTION
## Why?
We missed the m6web/http-kernel-bundle.

## How?
Add it to the suggest list, and explain its usage when shown in the doc.
