### PR TITLE
Use master request on MetricHandler

### DIFF
--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -215,7 +215,7 @@ class M6WebStatsdPrometheusExtension extends Extension
             // such as '@=container.get('kernel')'
             // See the documentation for further help
             ->addMethodCall('setContainer', [new Reference('service_container')])
-            ->addMethodCall('setCurrentRequest', [new Reference('request_stack')]);
+            ->addMethodCall('setRequestStack', [new Reference('request_stack')]);
     }
 
     protected function getMetricUdpClientDefinition(string $clientName, string $serverName): Definition

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -316,7 +316,7 @@ If you don't need it, use the null value: `~`.
 
 2 services are injected into tag value resolution: 
 - `container` = container
-- `request` = current request. This is an alias for `container.get('request_stack').getCurrentRequest()`
+- `request` = master request. This is either from the handled event (if it is a KernelEvent) or an alias for `container.get('request_stack').getMasterRequest()`
 
 To activate those resolvers, you need to add: `@=` at the beggining of you tag value:
 ```yaml
@@ -338,7 +338,7 @@ Ten, you can use more complicated tests to check a value:
 #Logic operator
 tagName3: '@=request.get("X-Header") &&  not(request.get("X-Header-secondary")) ? "yes" : "no"'
 #Regex
-tagName3: '@=request.get("X-Header") matches "/def.*ult/" ? "yes" : "no"'
+tagName4: '@=request.get("X-Header") matches "/def.*ult/" ? "yes" : "no"'
 ```
 
 Please, have a look at the documentation syntax to go further in your usage: [ExpressionLanguage syntax](https://symfony.com/doc/current/components/expression_language/syntax.html).

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -6,6 +6,7 @@ use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEventInterface;
 use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class Metric implements MetricInterface
@@ -139,6 +140,10 @@ class Metric implements MetricInterface
 
         // Add global parameters (configured in client or group)
         if (is_array($this->configurationTags)) {
+            if ($this->event instanceof KernelEvent && $this->event->isMasterRequest()) {
+                $resolvers['request'] = $this->event->getRequest();
+            }
+
             foreach ($this->configurationTags as $tagKey => $tagValue) {
                 $tags[$tagKey] = $this->resolveTagValue($tagValue, $resolvers);
             }

--- a/Metric/MetricHandler.php
+++ b/Metric/MetricHandler.php
@@ -5,7 +5,6 @@ namespace M6Web\Bundle\StatsdPrometheusBundle\Metric;
 use M6Web\Bundle\StatsdPrometheusBundle\Client\ClientInterface;
 use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class MetricHandler
@@ -18,8 +17,8 @@ class MetricHandler
     /** @var ContainerInterface */
     protected $container;
 
-    /** @var Request */
-    protected $currentRequest;
+    /** @var RequestStack */
+    protected $requestStack;
 
     /** @var \SplQueue */
     protected $metrics;
@@ -97,9 +96,9 @@ class MetricHandler
         $this->container = $container;
     }
 
-    public function setCurrentRequest(RequestStack $requestStack): void
+    public function setRequestStack(RequestStack $requestStack): void
     {
-        $this->currentRequest = $requestStack->getCurrentRequest();
+        $this->requestStack = $requestStack;
     }
 
     public function setMetricsQueue(\SplQueue $queue): void
@@ -176,7 +175,7 @@ class MetricHandler
             '%tags' => $this->formatTagsInline(
                 $metric->getResolvedTags([
                     'container' => $this->container,
-                    'request' => $this->currentRequest,
+                    'request' => $this->requestStack ? $this->requestStack->getMasterRequest() : null,
                 ])
             ),
         ]);


### PR DESCRIPTION
## Why?
We noticed some Fatals on prod (couldn't repro on localhost), traced it back to the tagResolver evaluating `request.header.get()`.

## How?
Use masterRequest which has less chances of not being instanciated, and more of having the data we're looking for.  
Also, when handling a KernelEvent having the master request, use this request as the stack may be empty.

## Todo
<!-- List things you'll have to do before merging/deploying -->
