### PR TITLE
Fix parameter key used on monitoring events tags

### DIFF
--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -150,25 +150,24 @@ class Metric implements MetricInterface
         }
 
         foreach ($this->tags as $tagName => $tagAccessor) {
+            // Legacy support
+            // Try to get the tag value from a function in the event
+            try {
+                if ($tagAccessor === null) {
+                    // fallback in the case a tag accessor has not been defined
+                    //we try to access the value with the tag name
+                    $tagAccessor = $tagName;
+                }
+                $tags[$tagName] = $this->propertyAccessor->getValue($this->event, $tagAccessor);
+
+                continue;
+            } catch (\Exception $e) {
+            }
+
             // Recommended Event type
-            if ($this->event instanceof MonitoringEventInterface) {
-                // If the event is a valid type, we can access custom Tags values
-                if ($this->event->hasParameter($tagAccessor)) {
-                    // Add every metric "tag" parameters, configured in the event metric
-                    $tags[$tagName] = $this->event->getParameter($tagAccessor);
-                }
-            } else {
-                // Legacy support
-                // Try to get the tag value from a function in the event
-                try {
-                    if (is_null($tagAccessor)) {
-                        // fallback in the case a tag accessor has not been defined
-                        //we try to access the value with the tag name
-                        $tagAccessor = $tagName;
-                    }
-                    $tags[$tagName] = $this->propertyAccessor->getValue($this->event, $tagAccessor);
-                } catch (\Exception $e) {
-                }
+            if ($this->event instanceof MonitoringEventInterface && $this->event->hasParameter($tagAccessor)) {
+                // Add every metric "tag" parameters, configured in the event metric
+                $tags[$tagName] = $this->event->getParameter($tagAccessor);
             }
         }
 

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -153,9 +153,9 @@ class Metric implements MetricInterface
             // Recommended Event type
             if ($this->event instanceof MonitoringEventInterface) {
                 // If the event is a valid type, we can access custom Tags values
-                if ($this->event->hasParameter($tagName)) {
+                if ($this->event->hasParameter($tagAccessor)) {
                     // Add every metric "tag" parameters, configured in the event metric
-                    $tags[$tagName] = $this->event->getParameter($tagName);
+                    $tags[$tagName] = $this->event->getParameter($tagAccessor);
                 }
             } else {
                 // Legacy support


### PR DESCRIPTION
## Why?
Given following event:

```yml
- type: 'timer'
  name: 'http_request_input_seconds'
  param_value: 'getTiming'
  tags:
    status: 'statusCode'
    route: 'routeName'
```

The metric would try to resolve `status` tag by taking the `status` parameter on the event instead of the `statusCode`.
