### PR TITLE
Provide built-in events to tag kernel.terminate/exception

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -8,20 +8,10 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * @var string
-     */
-    private $configurationRootKey;
-
-    public function __construct(string $configurationRootKey)
-    {
-        $this->configurationRootKey = $configurationRootKey;
-    }
-
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root($this->configurationRootKey);
+        $rootNode = $treeBuilder->root(M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY);
 
         $this->addMetricsSection($rootNode);
         $this->addServersSection($rootNode);

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -460,22 +460,31 @@ m6web_statsd_prometheus:
             groups:
                 default_group:
                     events:
-                        kernel.terminate:
+                        statsdtagsprometheus.kernelterminate:
                             metrics:
                                 -   type: 'increment'
                                     #project name and dynamics values are removed here for the metric name
                                     #we also provide a better name according to the naming convention
                                     name: 'http_request_total' 
                                     tags: #dynamic values are set in tags
-                                        host: 'request_host'
-                                        status: 'response.statusCode'
-                        kernel.exception:
+                                        host: 'host'
+                                        status: 'statusCode'
+                                -   type: 'timer'
+                                    #project name and dynamics values are removed here for the metric name
+                                    #we also provide a better name according to the naming convention
+                                    name: 'http_request_input_seconds' 
+                                    param_value: 'getTiming'
+                                    tags: #dynamic values are set in tags
+                                        route: 'routeName'
+                                        host: 'host'
+                                        status: 'statusCode'
+                        statsdtagsprometheus.kernelexception:
                             metrics:
                                 -   type: 'increment'                                                                    
                                     #we provide a better name according to the naming convention
                                     name: 'http_error_count' 
                                     tags:
-                                        code: 'exception.code'
+                                        code: 'statusCode'
                         redis.command:
                             metrics:
                                 -   type: 'increment'

--- a/Doc/usage.md
+++ b/Doc/usage.md
@@ -1,5 +1,21 @@
 # Usage
 
+## Built-in events
+
+### 1. `statsdtagsprometheus.kernelterminate`
+
+This event decorates the `kernel.terminate` event and add useful monitoring metrics on top:
+- StatusCode (200/404/5xx/...)
+- RouteName (from symfony routing)
+- MethodName (GET/POST/...)
+- Timing (time elapsed since php started exection of the request)
+- Memory (maximum memory allocated)
+- Host (http host requested by the browser)
+
+### 2. `statsdtagsprometheus.kernelexception`
+
+This event is provided for backward compatibility for your apps that used to use our `m6web/http-kernel-bundle` bundle. It provides the http response code sent.
+
 ## Dispatch your events
 
 ### Using MonitoringEventInterface

--- a/Event/KernelExceptionEvent.php
+++ b/Event/KernelExceptionEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * evenement surchargeant le kernel.exception de sf2
+ */
+class KernelExceptionEvent extends Event
+{
+    private $code;
+
+    /**
+     * constructeur
+     *
+     * @param int $code code
+     */
+    public function __construct($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * retourne le statuscode
+     *
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->code;
+    }
+}

--- a/Event/KernelExceptionEvent.php
+++ b/Event/KernelExceptionEvent.php
@@ -5,31 +5,27 @@ declare(strict_types=1);
 namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
 /**
- * evenement surchargeant le kernel.exception de sf2
+ * Decorates kernel.exception event with monitoring data
  */
 class KernelExceptionEvent extends Event
 {
-    private $code;
+    /** @var GetResponseForExceptionEvent */
+    private $event;
 
-    /**
-     * constructeur
-     *
-     * @param int $code code
-     */
-    public function __construct($code)
+    public function __construct(GetResponseForExceptionEvent $event)
     {
-        $this->code = $code;
+        $this->event = $event;
     }
 
-    /**
-     * retourne le statuscode
-     *
-     * @return int
-     */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
-        return $this->code;
+        if (method_exists($this->event->getException(), 'getStatusCode')) {
+            return $this->event->getException()->getStatusCode();
+        }
+
+        return 500;
     }
 }

--- a/Event/KernelTerminateEvent.php
+++ b/Event/KernelTerminateEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Event;
+
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+
+/**
+ * Evènement surchargeant le kernel.terminate
+ */
+class KernelTerminateEvent extends PostResponseEvent
+{
+    public function getStatusCode(): int
+    {
+        return $this->getResponse()->getStatusCode();
+    }
+
+    public function getRouteName(): string
+    {
+        return $this->getRequest()->get('_route', 'undefined');
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->getRequest()->getMethod();
+    }
+
+    public function getTiming(): float
+    {
+        return microtime(true) - $this->getRequest()->server->get('REQUEST_TIME_FLOAT');
+    }
+
+    public function getMemory(): int
+    {
+        return memory_get_peak_usage(true);
+    }
+
+    public function getHost(): string
+    {
+        return str_replace('.', '_', $this->getRequest()->getHost());
+    }
+}

--- a/Listener/EventListener.php
+++ b/Listener/EventListener.php
@@ -2,11 +2,9 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\Listener;
 
-use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEvent;
 use M6Web\Bundle\StatsdPrometheusBundle\Metric\Metric;
 use M6Web\Bundle\StatsdPrometheusBundle\Metric\MetricHandler;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\PropertyAccess;
 
 class EventListener
@@ -51,15 +49,6 @@ class EventListener
      */
     public function onKernelTerminate(PostResponseEvent $event): void
     {
-        $this->handleEvent(new MonitoringEvent([
-            'statusCode' => $event->getResponse()->getStatusCode(),
-            'routeName' => $event->getRequest()->get('_route', 'undefined'),
-            'methodName' => $event->getRequest()->getMethod(),
-            'timing' => microtime(true) - $event->getRequest()->server->get('REQUEST_TIME_FLOAT'),
-            'memory' => memory_get_peak_usage(true),
-            'host' => str_replace('.', '_', $event->getRequest()->getHost()),
-        ]), KernelEvents::TERMINATE);
-
         $this->metricHandler->sendMetrics();
     }
 

--- a/Listener/KernelEventsListener.php
+++ b/Listener/KernelEventsListener.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace M6Web\Bundle\StatsdPrometheusBundle\Listener;
+
+use M6Web\Bundle\StatsdPrometheusBundle\Event\KernelExceptionEvent;
+use M6Web\Bundle\StatsdPrometheusBundle\Event\KernelTerminateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class KernelEventsListener implements EventSubscriberInterface
+{
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function onKernelTerminate(PostResponseEvent $event)
+    {
+        $this->dispatcher->dispatch('statsdtagsprometheus.kernelterminate',
+            new KernelTerminateEvent(
+                $event->getKernel(),
+                $event->getRequest(),
+                $event->getResponse()
+            ));
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return;
+        }
+
+        if (method_exists($event->getException(), 'getStatusCode')) {
+            $this->dispatcher->dispatch(
+                'statsdtagsprometheus.kernelexception',
+                new KernelExceptionEvent($event->getException()->getStatusCode())
+            );
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onKernelException',
+            KernelEvents::TERMINATE => 'onKernelTerminate',
+        ];
+    }
+}

--- a/M6WebStatsdPrometheusBundle.php
+++ b/M6WebStatsdPrometheusBundle.php
@@ -2,18 +2,33 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle;
 
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class M6WebStatsdPrometheusBundle extends Bundle
 {
     /**
-     * trick allowing bypassing the Bundle::getContainerExtension check on getAlias
-     * not very clean, to investigate
+     * Returns the bundle's container extension.
      *
-     * @return object DependencyInjection\M6WebStatsdExtension
+     * With our `M6Web` namespace, symfony's `Container::underscore()` gives aliases starting with `m6_web`
+     * but we always used `m6web`, thus the consistency check here is removed.
+     *
+     * @return ExtensionInterface|null The container extension
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
-        return new DependencyInjection\M6WebStatsdPrometheusExtension();
+        if (null === $this->extension) {
+            $extension = $this->createContainerExtension();
+
+            if (null !== $extension) {
+                $this->extension = $extension;
+            } else {
+                $this->extension = false;
+            }
+        }
+
+        if ($this->extension) {
+            return $this->extension;
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,5 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
-    },
-    "suggest": {
-        "m6web/http-kernel-bundle": "Add the timing to the kernel terminate event."
     }
 }


### PR DESCRIPTION
## Why?
We previously suggested (#9) to use our m6webkernel bundle to provide timings on kernel events but this just add steps and dependencies to configuring this bundle.

## How?
- Add a listener and events, just like the custom kernel bundle
- 🎁 investigated and clarified the `Bundle::getContainerExtension()` situation
- 🎁 can cut some code away with `ConfigurableExtension`

## Todo
<!-- List things you'll have to do before merging/deploying -->
