### PR TITLE
fix datacollector_template

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,8 +10,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root(M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY);
+        $treeBuilder = new TreeBuilder(M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY);
+        $rootNode = $this->getRootNode($treeBuilder, M6WebStatsdPrometheusExtension::CONFIG_ROOT_KEY);
 
         $this->addMetricsSection($rootNode);
         $this->addServersSection($rootNode);
@@ -107,8 +107,10 @@ class Configuration implements ConfigurationInterface
 
     private function getClientsGroupsEvents()
     {
-        return (new TreeBuilder())
-            ->root('events')
+        $treeBuilder = new TreeBuilder('events');
+        $eventsNode = $this->getRootNode($treeBuilder, 'events');
+
+        $eventsNode
             ->cannotBeEmpty()
             ->useAttributeAsKey('eventName')
             ->prototype('array')
@@ -130,5 +132,17 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+
+        return $eventsNode;
+    }
+
+    private function getRootNode(TreeBuilder $treeBuilder, $name)
+    {
+        // BC layer for symfony/config 4.1 and older
+        if (!\method_exists($treeBuilder, 'getRootNode')) {
+            return $treeBuilder->root($name);
+        }
+
+        return $treeBuilder->getRootNode();
     }
 }

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -178,7 +178,7 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
         $definition = new Definition(StatsdDataCollector::class);
         $definition->setPublic(true);
         $definition->addTag('data_collector', [
-            'template' => '@M6WebStatsd/Collector/statsd.html.twig',
+            'template' => '@M6WebStatsdPrometheus/Collector/statsd_prometheus.html.twig',
             'id' => 'statsd',
         ]);
 

--- a/Resources/views/Collector/statsd_prometheus.html.twig
+++ b/Resources/views/Collector/statsd_prometheus.html.twig
@@ -6,7 +6,7 @@
     {% endset %}
     {% set text %}
         <div class="sf-toolbar-info-piece">
-            <b>Statsd</b>
+            <b>Statsd prometheus</b>
             <span>{{ collector.operations }}</span>
         </div>
     {% endset %}
@@ -22,7 +22,7 @@
     <span class="icon">{% spaceless %}
     <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAEVUlEQVRYhe2Wz0sVaxjHP+/8OOdM53SmOJwgMTtYSHBBTLDFrUjolmvBIxiCFLhI6F5xIbToD3Aj6d3VQgqiRYu6riJaWd3ERUq20pQDSgv1kkiemTMzZ9670JnrHH9gxPXehQ8MM/N93/f5fp8f78wLh3Zo/7GJ4OGXa9cWTPNY9UGQuq5rj/7xwgDQAtA0j1X/Pjx0EPzc+fW3RPCsVQ52dXWRSqWIxWJomkYul2NhYSEcF0Jw6tSpCAaEmJQyxKqrqykUCnieh+M4WJbFyMhIZF0oIFiYTCZZXV0lk8lgGAZCCJLJJIqi/LNI0zh69GjUkaaRSqXCd9/3EUKgqirFYpHl5WWqqqoiXBEBvu+HjtLpNJlMhnQ6jWmaKIqCECLMgGma29IaYIFzKSWpVIpsNouu69i2ja7rEa4dM6AoCpqmoes6mqaFkW917Pt+xEngtBJTFAVd18Or0teOAnK5HJZlcfz4cRKJBKVSiUQiEXG8X8xxHNLpNLquU1VVRXt7O4qi7F2C+fl5bNtmfX2dRCJBNptleXk54ng3bG1tjVKpFMGWlpYwTZN8Ps/Tp0+5efPm3iWQUuI4DrZt4/s+pVKJYrG4LdpKLBaL0d3dzdraGuPj40xNTVEqlfB9n7a2Nt6/f8/09DTxeHzvEgSklmXhed6+BbS0tDA2Nsbi4iJXr17l8uXLzM3NcfLkST5+/MjDhw+pra2NcO1Ygq1R67q+LwGtra3Yts2zZ89QVZU3b95w9uxZWltbmZmZYWRkBCFEhGPXDORyOeLxOIZhoKoqtm1z4sSJiICt2Llz57hw4QJDQ0OcPn06nOM4Do8ePUIIQW1tLcVikZqamt0zIDdVff78mfn5eVKpFFeuXOHWrVuMjo7y6tWrMOozZ84wNzfHkSNH6OnpYXBwEMuyKBQKEaHBPNd1+fbtG47jRLgAws9buaIETU1N5PN5Xr58iWEYDA8P09XVRTKZDEtw+/Zt3r59y8TEBJ7nUSwWI1cwz7IsbNumXC5HuCIZCAZ93+fSpUt0dnbS399PLBZjdnaWx48fc+PGDe7fv8+nT58oFApomsaDBw9wHGfPXgmaORSweY9moFxGSklTUxPd3d309vYyMzODEALHcfjy5QsDAwN0dHRQKBRoaGhgYGCAr1+/RqKtzMD6+jqWZYVbUkoZERCeB36+eFG+eP6clZUV7t69y8rKCqqqUmlSSlzXxXVdDMOI/KR2s4C0vr6ee/fukW9v589370SkBH7ZZ3V1lb6+Pl6/fo0QAiEEjY2NfPjwIeKwsbGR6enpbVjlvPPnzzM5OYmUEikl8Xh8YzuWd+gBr1wmmUyGNQvMdd2we78XC84BWzMhpcTbrQeAfaX0R21rD2wpQTn85zc3N4cT6urqth0+fgTbKMFOAjb35pMnT74vnO+0jfOEhI3s+xqgqaqatWzrr+vXWzL/KvumlX3f1XX9J8/zZg+C79D+3/Y3WY+lvPQgrdQAAAAASUVORK5CYII=" alt="Statsd" />
         {% endspaceless %}</span>
-    <strong>Statsd</strong>
+    <strong>Statsd prometheus</strong>
     <span class="count">
         <span>{{ collector.operations }}</span>
     </span>
@@ -30,7 +30,7 @@
 {% endblock %}
 
 {% block panel %}
-    <h2>Statsd</h2>
+    <h2>Statsd prometheus</h2>
     {% for clientInfo in collector.clients %}
         Client : {{ clientInfo.name }}<br />
         <table class="routing inline">


### PR DESCRIPTION
## Why?
<!-- Explain why you've done it like this -->
Template error 
A tree builder without a root node is deprecated since Symfony 4.2 : https://symfony.com/blog/new-in-symfony-4-2-important-deprecations

## How?
<!-- Explain how you've done it -->
Fix Template
Fix tree builder 

