### PR TITLE
Add missing expression language dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "php": "^7.1",
-        "symfony/property-access": "^3.4 || ^4.0"
+        "symfony/property-access": "^3.4 || ^4.0",
+        "symfony/expression-language": "^3.4 || ^4.0"
     },
     "require-dev": {
         "m6web/php-cs-fixer-config": "^1.0",


### PR DESCRIPTION
## Why?
Since `symfony/expression-language` is used here:
https://github.com/M6Web/StatsdTagsPrometheusBundle/blob/master/Metric/Metric.php#L64
It should be defined as a mandatory dependency.

## How?
Required dependency added to `composer.json`.