### PR TITLE
fix(request_stack) get master request from request stack to keep its original state

### DIFF
--- a/Client/UdpClient.php
+++ b/Client/UdpClient.php
@@ -10,9 +10,13 @@ class UdpClient implements ClientInterface
     /** @var ServerInterface */
     protected $server;
 
-    public function __construct(ServerInterface $server)
+    /** @var bool */
+    protected $debugEnabled;
+
+    public function __construct(ServerInterface $server, ?bool $debugEnabled = false)
     {
         $this->server = $server;
+        $this->debugEnabled = $debugEnabled;
     }
 
     /**
@@ -37,7 +41,7 @@ class UdpClient implements ClientInterface
                     continue;
                 }
 
-                if (!@fwrite($resource, $line)) {
+                if (!@fwrite($resource, $this->getFormattedLine($line))) {
                     return false;
                 }
             }
@@ -48,5 +52,15 @@ class UdpClient implements ClientInterface
         }
 
         return false;
+    }
+
+    protected function getFormattedLine($line)
+    {
+        if ($this->debugEnabled) {
+            //With debug mode on, we add a carriage return to provide more readable data
+            return $line."\n";
+        }
+
+        return $line;
     }
 }

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -63,8 +63,7 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
 
         $this->container->autowire(KernelEventsListener::class)->setAutoconfigured(true);
 
-        if ($this->container->hasParameter('kernel.debug')
-            && $this->container->getParameter('kernel.debug')) {
+        if ($this->isDebugEnabled()) {
             $this->loadDebugConfiguration();
         }
     }
@@ -217,13 +216,14 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
             // such as '@=container.get('kernel')'
             // See the documentation for further help
             ->addMethodCall('setContainer', [new Reference('service_container')])
-            ->addMethodCall('setRequestStack', [new Reference('request_stack')]);
+            ->addMethodCall('setMasterRequestFromRequestStack', [new Reference('request_stack')]);
     }
 
     protected function getMetricUdpClientDefinition(string $clientName, string $serverName): Definition
     {
         return new Definition(UdpClient::class, [
             $this->getClientServerDefinition($clientName, $serverName),
+            $this->isDebugEnabled(),
         ]);
     }
 
@@ -261,5 +261,11 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
                 ['event' => 'console.terminate', 'method' => 'onTerminate']
             )
             ->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')]);
+    }
+
+    protected function isDebugEnabled()
+    {
+        return $this->container->hasParameter('kernel.debug')
+            && $this->container->getParameter('kernel.debug');
     }
 }

--- a/Tests/Metric/MetricHandlerTest.php
+++ b/Tests/Metric/MetricHandlerTest.php
@@ -223,7 +223,7 @@ class MetricHandlerTest extends TestCase
         $metricHandler = $this->getMetricHandlerObject();
         $requestStack = new RequestStack();
         $requestStack->push($masterRequest);
-        $metricHandler->setRequestStack($requestStack);
+        $metricHandler->setMasterRequestFromRequestStack($requestStack);
         // -- Then --
         $this->assertSame($expectedResult, $metricHandler->getFormattedMetric($metric));
     }


### PR DESCRIPTION
## Why?
<!-- Explain why you've done it like this -->
Symfony 4.2 seems to have changed the request stack lifecycle since we started to use this bundle.
Now the requestStack is emptied before we use it, so we cannot resolve our special configuration tags anymore:
```
dynamic_one: '@=container.get("my_service_id").getMyValue()' 
another_dynamic_one: '@=request.get("X-Custom-Header")' 
```

## How?
<!-- Explain how you've done it -->
By getting the master request from the requestStack  when it is instantiated, and keep its original state until the kernel terminate phase.

## Todo
* [x] Set the master request when we get the requestStack
* [x] Change code order between legacy and new behaviour