### PR TITLE
Prefixes all tags

### DIFF
--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -278,9 +278,9 @@ Configure the tags
 ### Tags scopes
 
 There are 3 types of tag that you can use: 
-* __global tag__: it is sent with every event metric. Its value is set in the config file.
-* __group tag__: it is sent with every event metric of the same group. Its value is set in the config file.
-* __metric tag__: it is sent only for the current event metric. Its value is sent with the event.  
+* __global tag__: it is sent with every event metric.
+* __group tag__: it is sent with every event metric of the same group.
+* __metric tag__: it is sent only for the current event metric.  
 
 Here is an example of how to define those 3 types:
 
@@ -323,16 +323,18 @@ m6web_statsd_prometheus:
 
 ### Tag option / structure
 
-* `{key}` = tag name
-
 The key corresponds to the tag name that will be sent to Prometheus.
 
-* `{value}` = property accessor
+* `{key}` = tag name
 
-You can define, as a value, a property acessor that will return the tag value.
-This is used for legacy purposes, when you work with specific event classes.
+The value can have different meanings.
 
-If you don't need it, use the null value: `~`.
+* `{value}` = some value
+   * Starting with `@=`, it will use a tag resolver, see [below](#tag-resolvers).
+   * Starting with `->`, it will try to resolve the followed attribute, see [below](#tag-properties)
+   * Starting with `%=`, it will try to get this parameter if the event implements the `MonitoringEventInterface`.
+   * A static value can also be used.
+   * A null value (or `~`) will try to resolve the `key` like it was a parameter (`%=key`).
 
 ### Tag resolvers
 
@@ -340,7 +342,6 @@ If you don't need it, use the null value: `~`.
 - `container` = container
 - `request` = master request. This is either from the handled event (if it is a KernelEvent) or an alias for `container.get('request_stack').getMasterRequest()`
 
-To activate those resolvers, you need to add: `@=` at the beggining of you tag value:
 ```yaml
 tagName: '@=request.get("X-Header")'
 ```
@@ -367,19 +368,18 @@ Please, have a look at the documentation syntax to go further in your usage: [Ex
 
 :warning: This works only for global and group configuration tags.
 
-### Send tags with event metrics
-
-When you set a tag in a metric, the bundle will look for an associated value to return.
-
-If you use the new format, it will look for a parameter named after your tag.
-
-A compatibility fallback will automatically look into your event object.
-First, if you have defined a property accessor, it will get the tag value there.
-Otherwise, it will check if there is a public accessor associated to your tag name. 
-
-This works like the former placeholders. 
-
 See [Usage documentation](usage-and-examples.md) for further explanations. 
+
+### Tag properties
+
+You can use the [Symfony property accessor](https://symfony.com/doc/current/components/property_access.html) to get values from your event.
+
+```yaml
+tagName: `->propertyName`
+```
+
+This will try to get the value of you event's public attribute `propertyName` or try to access it with a getter (`getPropertyName`).
+See the Symfony documentation for more information.
 
 
 ### Tag priority and overriding

--- a/Doc/upgrades/from-1-to-2.md
+++ b/Doc/upgrades/from-1-to-2.md
@@ -1,0 +1,14 @@
+Upgrade from version 1 to 2
+======
+
+### tags differences
+
+All tags can now be defined the same way, whether they are from the configuration, a group or from an event.
+
+### tags definition
+
+ * To resolve a tag from the `container` or the `request`, nothing changes.
+ * To resolve a tag from a parameter (within a `MonitoringEventInterface`), you must now prefix it with `%=`.
+ * To resolve a tag from a property (within an event), you must now prefix it with `->`.
+ * A null value (`~`) will no longer try to access the property with `key`, but only the parameter.
+ * You can now use static values from everywhere.

--- a/Doc/usage-and-examples.md
+++ b/Doc/usage-and-examples.md
@@ -170,8 +170,8 @@ m6web_statsd_prometheus:
             address: 'udp://localhost'
             port: 1236
     tags:
-        tagA: 'tagValue1'
-        tagB: 'tagValue2'
+        tagA: 'tagValue1' # static value
+        tagB: 'tagValue2' # static value
     clients: #clients
         default:
             max_queued_metrics: 10000 #optional
@@ -179,8 +179,8 @@ m6web_statsd_prometheus:
             groups: #groups
                 groupA:
                     tags:
-                        tagC: 'tagValue3'
-                        tagD: 'tagValue4'
+                        tagC: 'tagValue3' #static value
+                        tagD: 'tagValue4' #static value
                     events: #events types
                         eventName1:
                             metrics:
@@ -188,8 +188,8 @@ m6web_statsd_prometheus:
                                     name: 'metric_name'
                                     param_value: 'counterValue'
                                     tags:
-                                        tagE: ~
-                                        tagF: ~
+                                        tagE: ~ # event's parameter "tagE"
+                                        tagF: ~ # event's parameter "tagF"
                         eventName2:
                             flush_metrics_queue: true
                             metrics:
@@ -213,7 +213,7 @@ m6web_statsd_prometheus:
                                     name: 'metric_name4'
                                     param_value: 'myGauge'
                                     tags:
-                                        tagE: ~
+                                        tagE: ~ # event's parameter "tagE"
                         eventName5:
                             metrics:
                                 -   type: 'timer'

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Statsd Bundle for Prometheus.
 
 * Bind any event to increment metrics, set gauges and collect timers
 * Send Statsd metrics ([DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) format)
- compatible with Prometheus 
+* Version 1.6 is compatible with Prometheus 
 (converted with [statsd_exporter](https://github.com/prometheus/statsd_exporter))
+* Version 2+ adds new features and the configuration changed a bit, [see upgrade doc](Doc/upgrades/from-1-to-2.md)
 * Handle Prometheus tags in the metrics  
  
 ## Requirements

--- a/Tests/Metric/MetricHandlerTest.php
+++ b/Tests/Metric/MetricHandlerTest.php
@@ -514,8 +514,8 @@ class MetricHandlerTest extends TestCase
                     'tags' => [
                         'country' => null,
                         'platform' => null,
-                        'placeHolder1' => null,
-                        'normalized_tags_name' => 'placeHolder2',
+                        'placeHolder1' => '->placeHolder1',
+                        'normalized_tags_name' => '->placeHolder2',
                     ],
                 ],
                 // We are supposed to get the metric name, type, the custom parameter value and all the tags

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -2,9 +2,12 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\Tests\Metric;
 
+use Fixtures\CustomEventTest;
 use M6Web\Bundle\StatsdPrometheusBundle\Event\MonitoringEvent;
 use M6Web\Bundle\StatsdPrometheusBundle\Metric\Metric;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class MetricTest extends TestCase
 {
@@ -165,50 +168,321 @@ class MetricTest extends TestCase
     /**
      * @dataProvider dataProviderGetMetricsTag
      */
-    public function testGetResolvedTagsReturnsExpected($event, $metricConfig, $expectedResult)
+    public function testGetResolvedTagsReturnsExpected($event, array $metricConfig, array $resolvers, array $expectedResult)
     {
         // -- Given --
         $metric = new Metric($event, $metricConfig);
         // -- Expects
-        $this->assertSame($expectedResult, $metric->getResolvedTags());
+        $this->assertSame($expectedResult, $metric->getResolvedTags($resolvers));
     }
 
-    public function dataProviderGetMetricsTag()
+    public function dataProviderGetMetricsTag(): \Generator
     {
-        return [
+        $resolvers = [];
+
+        $monitoringEvent = new MonitoringEvent(
             [
-                new MonitoringEvent(['tag1' => 'tag_value']),
-                [
-                    'type' => 'increment',
-                    'name' => 'http_request_total',
-                    'configurationTags' => [],
-                    'tags' => [
-                        'tag1' => null,
-                    ],
+                'resolved_tag' => 'resolved-value-auto',
+                'explicit_tag' => 'explicit-value',
+                'configuration' => 'configuration-parameter',
+                'tags' => 'tag-parameter',
+            ]
+        );
+
+        // Working as expected use cases.
+
+        yield 'empty' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
                 ],
-                [
-                    'tag1' => 'tag_value',
+                'tags' => [
                 ],
             ],
+            $resolvers,
             [
-                new MonitoringEvent([
-                    'tag1' => 'tag_value',
-                    'tag2' => 'tag_value2',
-                    'wrongTag' => 'willBeIgnored',
-                ]),
-                [
-                    'type' => 'increment',
-                    'name' => 'http_request_total',
-                    'configurationTags' => [],
-                    'tags' => [
-                        'tag1' => null,
-                        'tag2' => null,
-                    ],
+            ],
+        ];
+
+        yield 'static-from-config' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'resolved_tag' => 'configuration-value',
                 ],
-                [
-                    'tag1' => 'tag_value',
-                    'tag2' => 'tag_value2',
+                'tags' => [
                 ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'configuration-value',
+            ],
+        ];
+
+        yield 'static-from-tags' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                ],
+                'tags' => [
+                    'resolved_tag' => 'tag-value',
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'tag-value',
+            ],
+        ];
+
+        yield 'parameter-from-config' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'resolved_tag' => '%=configuration',
+                ],
+                'tags' => [
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'configuration-parameter',
+            ],
+        ];
+
+        yield 'parameter-from-tags' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                ],
+                'tags' => [
+                    'resolved_tag' => '%=tags',
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'tag-parameter',
+            ],
+        ];
+
+        yield 'implicit-parameter-from-config' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'resolved_tag' => null,
+                ],
+                'tags' => [
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'resolved-value-auto',
+            ],
+        ];
+
+        yield 'implicit-parameter-from-tags' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                ],
+                'tags' => [
+                    'resolved_tag' => null,
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'resolved-value-auto',
+            ],
+        ];
+
+        $customEvent = new CustomEventTest(null, 'property-value-1', 'property-value-2');
+
+        yield 'property-from-config' => [
+            $customEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'resolved_tag' => '->placeholder1',
+                ],
+                'tags' => [
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'property-value-1',
+            ],
+        ];
+
+        yield 'property-from-tags' => [
+            $customEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                ],
+                'tags' => [
+                    'resolved_tag' => '->placeholder2',
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'property-value-2',
+            ],
+        ];
+
+        $resolvers = [
+            'container' => new Container(
+                new ParameterBag(
+                    [
+                        'test_configuration_value' => 'container-configuration-value',
+                        'test_tag_value' => 'container-tag-value',
+                    ]
+                )
+            ),
+        ];
+
+        yield 'container-from-config' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'resolved_tag' => '@=container.getParameter(\'test_configuration_value\')',
+                ],
+                'tags' => [
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'container-configuration-value',
+            ],
+        ];
+
+        yield 'container-from-tags' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                ],
+                'tags' => [
+                    'resolved_tag' => '@=container.getParameter(\'test_tag_value\')',
+                ],
+            ],
+            $resolvers,
+            [
+                'resolved_tag' => 'container-tag-value',
+            ],
+        ];
+
+        // Special cases that return null.
+
+        yield 'empty-values-are-filtered-out' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'empty_config' => '',
+                ],
+                'tags' => [
+                    'empty_tag' => 0,
+                ],
+            ],
+            $resolvers,
+            [
+            ],
+        ];
+
+        yield 'parameters-without-MonitoringEventInterface' => [
+            $customEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'empty_config' => '%=placeholder1',
+                ],
+                'tags' => [
+                    'resolved_tag' => '%=placeholder2',
+                ],
+            ],
+            $resolvers,
+            [
+            ],
+        ];
+
+        yield 'parameters-missing-from-MonitoringEventInterface' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'empty_config' => '%=placeholder1',
+                ],
+                'tags' => [
+                    'resolved_tag' => '%=placeholder2',
+                ],
+            ],
+            $resolvers,
+            [
+            ],
+        ];
+
+        yield 'parameters-missing-from-MonitoringEventInterface' => [
+            $customEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'empty_config' => '->placeholder3',
+                ],
+                'tags' => [
+                    'resolved_tag' => '->placeholder4',
+                ],
+            ],
+            $resolvers,
+            [
+            ],
+        ];
+
+        // All in one.
+
+        yield 'all-in' => [
+            $monitoringEvent,
+            [
+                'type' => 'increment',
+                'name' => 'http_request_total',
+                'configurationTags' => [
+                    'tag1' => '@=container.getParameter(\'test_configuration_value\')',
+                    'tag2' => 'static-value',
+                    'tag3' => '->PropertyNotFound',
+                ],
+                'tags' => [
+                    'tag4' => null,
+                    'tag5' => '%=explicit_tag',
+                    'resolved_tag' => null,
+                ],
+            ],
+            $resolvers,
+            [
+                'tag1' => 'container-configuration-value',
+                'tag2' => 'static-value',
+                'tag5' => 'explicit-value',
+                'resolved_tag' => 'resolved-value-auto',
             ],
         ];
     }


### PR DESCRIPTION
## Why?
We would like to make tags definition works the same anywhere.
This would allow for static value everywhere, and would also make it easier to read and understand.

Sadly, the cost of this change is a light increase in verbosity for the configuration, and the loss of the automatic fall-back from parameters to properties.
However I believe this will avoid unnecessary magic and makes the configuration really explicit.

## How?
This is up to discussion, but so far I've these 3 prefixes for none-static values.
 * `@=` for container and request resolver, as it was already done.
 * `%=` for parameters from the event implementing `MonitoringEventInterface`, returning null if it doesn't or doesn't have this parameter.
 * `->` for property accessors on the event, returning null if it is not found.

### To discuss
 * [ ] Should I put back the fall-back from parameters to property accessors? *I'm against it; too much magic…*
 * [ ] Should we allow for null value (`~`) to test the key as property accessors if the parameter doesn't exist? *No opinion.*
 * [ ] Should missing property or parameters throw an exception? *Events are volatile, I would rather not.*
 * [ ] Anything else?
