### PR TITLE
fix(max_queued_metrics) Allow to set max_queued_metrics parameter

### DIFF
--- a/Listener/EventListener.php
+++ b/Listener/EventListener.php
@@ -73,4 +73,9 @@ class EventListener
     {
         return $this->metricHandler;
     }
+
+    public function setMaxNumberOfMetricToQueue($maxNumberOfMetricToQueue): void
+    {
+        $this->metricHandler->setMaxNumberOfMetricToQueue($maxNumberOfMetricToQueue);
+    }
 }


### PR DESCRIPTION
## Why?
When max_queued_metrics option is set, there is a php fatal error because `setMaxNumberOfMetricToQueue()` function does not exists.

## How?
Add `setMaxNumberOfMetricToQueue()` function in the evenListener, which is required by setEventListenerAsServiceAndGetServiceId.php when max_queued_metrics option is set.

