### PR TITLE
Metrics unit correction

### DIFF
--- a/Event/ConsoleMonitoringEvent.php
+++ b/Event/ConsoleMonitoringEvent.php
@@ -19,7 +19,7 @@ class ConsoleMonitoringEvent extends MonitoringEvent
             'startTime' => $startTime,
             'executionTime' => $executionTime,
             'executionTimeHumanReadable' => ($executionTime * 1000),
-            'peakMemory' => self::getPeakMemory(),
+            'peakMemory' => self::getPeakMemoryInBytes(),
             'underscoredCommandName' => self::getUnderscoredEventCommandName($event),
             // The original event is sent as a parameter, just in case
             'originalEvent' => $event,
@@ -35,7 +35,7 @@ class ConsoleMonitoringEvent extends MonitoringEvent
         return null;
     }
 
-    protected static function getPeakMemory()
+    protected static function getPeakMemoryInBytes()
     {
         return memory_get_peak_usage(true);
     }

--- a/Event/ConsoleMonitoringEvent.php
+++ b/Event/ConsoleMonitoringEvent.php
@@ -37,9 +37,6 @@ class ConsoleMonitoringEvent extends MonitoringEvent
 
     protected static function getPeakMemory()
     {
-        $memory = memory_get_peak_usage(true);
-        $memory = ($memory > 1024 ? intval($memory / 1024) : 0);
-
-        return $memory;
+        return memory_get_peak_usage(true);
     }
 }

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -160,6 +160,17 @@ class MetricTest extends TestCase
                     'tags' => [],
                     'param_value' => 'customValue',
                 ],
+                '12045465000',
+            ],
+            [
+                new MonitoringEvent(['customValue' => 12045.465]),
+                [
+                    'type' => 'timer',
+                    'name' => 'http_request_total',
+                    'configurationTags' => [],
+                    'tags' => [],
+                    'param_value' => 'customValue',
+                ],
                 '12045465',
             ],
         ];


### PR DESCRIPTION
## Why?
There is some metrics inconsistencies we need to fix.
 - When expecting a console memory usage in bytes, we get kilobytes because the value is divided by 1024.
 - When using timers, values are divided 1000 by the statsd exporter (see https://github.com/prometheus/statsd_exporter/pull/178/files#diff-557eb2a359922e8de5f18397fed0cd99R423) which expects ms, while prometheus expects seconds. When sending seconds (with `microtime(true)`), values are now incorrect.

## How?
 - Remove the division by 1024 in the ConsoleMonitoringEvent.
 - Multiply timer values by 1000 for timer metrics.
