### PR TITLE
Fix/metrics null value

### DIFF
--- a/Client/Server.php
+++ b/Client/Server.php
@@ -18,9 +18,6 @@ class Server implements ServerInterface
     /**
      * Server constructor.
      *
-     * @param string $serverName
-     * @param array  $serverConfig
-     *
      * @throws ServerException
      */
     public function __construct(string $serverName, array $serverConfig)
@@ -34,11 +31,6 @@ class Server implements ServerInterface
 
     /**
      * Init the servers defined in the app configuration
-     *
-     * @param string $serverName
-     * @param array  $serverConfig
-     *
-     * @return bool
      *
      * @throws ServerException
      */

--- a/Client/UdpClient.php
+++ b/Client/UdpClient.php
@@ -21,8 +21,6 @@ class UdpClient implements ClientInterface
 
     /**
      * Split metrics to send them group by group
-     *
-     * @param array $lines
      */
     public function sendLines(array $lines): void
     {

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -113,10 +113,6 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
 
     /**
      * Add the "kernel event listener" tag on the given event listener service definition
-     *
-     * @param Definition $eventListenerDefinition
-     * @param array      $groupConfig
-     * @param array      $tagsConfig
      */
     protected function addEventListenerTagsOnServiceDefinition(Definition $eventListenerDefinition, array $groupConfig, array $tagsConfig): void
     {
@@ -234,11 +230,7 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
     {
         // No server found.
         if (!\array_key_exists($serverName, $this->servers)) {
-            throw new InvalidConfigurationException(sprintf(
-                'M6WebStatsd client %s used server %s which is not defined in the servers section',
-                $clientName,
-                $serverName
-            ));
+            throw new InvalidConfigurationException(sprintf('M6WebStatsd client %s used server %s which is not defined in the servers section', $clientName, $serverName));
         }
         // Matched server configurations.
         return new Definition(Server::class, [

--- a/Event/Console/AbstractConsoleMonitoringEvent.php
+++ b/Event/Console/AbstractConsoleMonitoringEvent.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Event\ConsoleEvent;
 
 abstract class AbstractConsoleMonitoringEvent extends AbstractMonitoringEvent
 {
-    public static function createFromConsoleEvent(ConsoleEvent $event, int $startTime = 0)
+    public static function createFromConsoleEvent(ConsoleEvent $event, ?int $startTime = null)
     {
         $executionTime = !is_null($startTime) ? microtime(true) - $startTime : null;
 

--- a/Event/Console/AbstractConsoleMonitoringEvent.php
+++ b/Event/Console/AbstractConsoleMonitoringEvent.php
@@ -5,7 +5,7 @@ namespace M6Web\Bundle\StatsdPrometheusBundle\Event\Console;
 use M6Web\Bundle\StatsdPrometheusBundle\Event\AbstractMonitoringEvent;
 use Symfony\Component\Console\Event\ConsoleEvent;
 
-abstract class AbstractConsoleAbstractMonitoringEvent extends AbstractMonitoringEvent
+abstract class AbstractConsoleMonitoringEvent extends AbstractMonitoringEvent
 {
     public static function createFromConsoleEvent(ConsoleEvent $event, int $startTime = 0)
     {

--- a/Event/Console/ConsoleCommandMonitoringEvent.php
+++ b/Event/Console/ConsoleCommandMonitoringEvent.php
@@ -2,6 +2,6 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\Event\Console;
 
-class ConsoleCommandMonitoringEvent extends AbstractConsoleAbstractMonitoringEvent
+class ConsoleCommandMonitoringEvent extends AbstractConsoleMonitoringEvent
 {
 }

--- a/Event/Console/ConsoleErrorMonitoringEvent.php
+++ b/Event/Console/ConsoleErrorMonitoringEvent.php
@@ -2,6 +2,6 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\Event\Console;
 
-class ConsoleErrorMonitoringEvent extends AbstractConsoleAbstractMonitoringEvent
+class ConsoleErrorMonitoringEvent extends AbstractConsoleMonitoringEvent
 {
 }

--- a/Event/Console/ConsoleExceptionMonitoringEvent.php
+++ b/Event/Console/ConsoleExceptionMonitoringEvent.php
@@ -2,6 +2,6 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\Event\Console;
 
-class ConsoleExceptionMonitoringEvent extends AbstractConsoleAbstractMonitoringEvent
+class ConsoleExceptionMonitoringEvent extends AbstractConsoleMonitoringEvent
 {
 }

--- a/Event/Console/ConsoleTerminateMonitoringEvent.php
+++ b/Event/Console/ConsoleTerminateMonitoringEvent.php
@@ -2,6 +2,6 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\Event\Console;
 
-class ConsoleTerminateMonitoringEvent extends AbstractConsoleAbstractMonitoringEvent
+class ConsoleTerminateMonitoringEvent extends AbstractConsoleMonitoringEvent
 {
 }

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ clean-composer:
 	$(call printSection,CLEAN-COMPOSER)
 	rm -rf ${SOURCE_DIR}/composer
 	rm -f ${SOURCE_DIR}/composer.install.log
+	rm -f ${SOURCE_DIR}/composer.lock
 
 # COMPOSER
 ${COMPOSER_BIN}:

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -50,7 +50,6 @@ class Metric implements MetricInterface
      * Metric constructor.
      *
      * @param object $event
-     * @param array  $metricConfig
      */
     public function __construct($event, array $metricConfig = [])
     {
@@ -101,10 +100,7 @@ class Metric implements MetricInterface
         }
         if (empty($this->paramValue)) {
             //The param value is required for every type, except for increment which is handled above.
-            throw new MetricException(
-                \sprintf('The configuration of the event metric "%s" must define the "param_value" option.',
-                    \get_class($this->event))
-            );
+            throw new MetricException(\sprintf('The configuration of the event metric "%s" must define the "param_value" option.', \get_class($this->event)));
         }
         if ($this->event instanceof MonitoringEventInterface) {
             // Using the valid event type, values are now in parameters
@@ -112,10 +108,7 @@ class Metric implements MetricInterface
         }
         if (!\method_exists($this->event, $this->paramValue)) {
             // Legacy compatibility
-            throw new MetricException(
-                \sprintf('The event class "%s" must have a "%s" method or parameters in order to measure value.',
-                    \get_class($this->event), $this->paramValue)
-            );
+            throw new MetricException(\sprintf('The event class "%s" must have a "%s" method or parameters in order to measure value.', \get_class($this->event), $this->paramValue));
         }
 
         return $this->correctValue(\call_user_func([$this->event, $this->paramValue]));

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -198,13 +198,17 @@ class Metric implements MetricInterface
         }
     }
 
-    private function correctValue(string $value): string
+    private function correctValue($value): string
     {
-        /* @see https://github.com/prometheus/statsd_exporter/pull/178/files#diff-557eb2a359922e8de5f18397fed0cd99R423 */
-        if ($this->getResolvedType() === self::STATSD_TYPE_TIMER) {
-            return $value * 1000;
+        if (!is_numeric($value)) {
+            $value = 0;
         }
 
-        return $value;
+        /* @see https://github.com/prometheus/statsd_exporter/pull/178/files#diff-557eb2a359922e8de5f18397fed0cd99R423 */
+        if ($this->getResolvedType() === self::STATSD_TYPE_TIMER) {
+            $value = $value * 1000;
+        }
+
+        return (string) $value;
     }
 }

--- a/Metric/MetricInterface.php
+++ b/Metric/MetricInterface.php
@@ -26,8 +26,6 @@ interface MetricInterface
      *                         ['resolver1' => $resolver1]
      *                         Used to inject services in tag names:
      *                         format: '@=my_service.myFunction()'
-     *
-     * @return array
      */
     public function getResolvedTags(array $resolvers): array;
 }

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -119,7 +119,7 @@ class MetricTest extends TestCase
     public function dataProviderGetMetricsValue()
     {
         return [
-            [
+            'increment value' => [
                 new TestMonitoringEvent(['placeHolder' => 'custom_name']),
                 [
                     'type' => 'increment',
@@ -129,7 +129,7 @@ class MetricTest extends TestCase
                 ],
                 '1',
             ],
-            [
+            'counter with fixed value' => [
                 new TestMonitoringEvent(['customValue' => 12]),
                 [
                     'type' => 'counter',
@@ -140,7 +140,7 @@ class MetricTest extends TestCase
                 ],
                 '12',
             ],
-            [
+            'gauge with fixed value' => [
                 new TestMonitoringEvent(['customValue' => 205]),
                 [
                     'type' => 'gauge',
@@ -151,7 +151,7 @@ class MetricTest extends TestCase
                 ],
                 '205',
             ],
-            [
+            'timer in ms with fixed value value corrected by 1000' => [
                 new TestMonitoringEvent(['customValue' => 12045465]),
                 [
                     'type' => 'timer',
@@ -162,7 +162,7 @@ class MetricTest extends TestCase
                 ],
                 '12045465000',
             ],
-            [
+            'timer in s with fixed value corrected by 1000' => [
                 new TestMonitoringEvent(['customValue' => 12045.465]),
                 [
                     'type' => 'timer',

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -205,6 +205,33 @@ class MetricTest extends TestCase
                 ],
                 '10002',
             ],
+            'timer returning null' => [
+                new TestMonitoringEvent(['customValue' => null]),
+                [
+                    'type' => 'timer',
+                    'name' => 'http_request_total',
+                    'configurationTags' => [],
+                    'tags' => [],
+                    'param_value' => 'customValue',
+                ],
+                '0',
+            ],
+            'custom value from object return null' => [
+                new class() {
+                    public function getCustomValue()
+                    {
+                        return null;
+                    }
+                },
+                [
+                    'type' => 'counter',
+                    'name' => 'http_request_total',
+                    'configurationTags' => [],
+                    'tags' => [],
+                    'param_value' => 'getCustomValue',
+                ],
+                '0',
+            ],
         ];
     }
 

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -173,6 +173,38 @@ class MetricTest extends TestCase
                 ],
                 '12045465',
             ],
+            'custom value from object' => [
+                new class() {
+                    public function getCustomValue()
+                    {
+                        return 10;
+                    }
+                },
+                [
+                    'type' => 'counter',
+                    'name' => 'http_request_total',
+                    'configurationTags' => [],
+                    'tags' => [],
+                    'param_value' => 'getCustomValue',
+                ],
+                '10',
+            ],
+            'custom value from object corrected by 1000' => [
+                new class() {
+                    public function getCustomValue()
+                    {
+                        return 10.002;
+                    }
+                },
+                [
+                    'type' => 'timer',
+                    'name' => 'http_request_total',
+                    'configurationTags' => [],
+                    'tags' => [],
+                    'param_value' => 'getCustomValue',
+                ],
+                '10002',
+            ],
         ];
     }
 


### PR DESCRIPTION
## Why?
Nothing force a value to not be null, but an error happens if it does.

## How?
Add test cases detecting this problem.
Force non numeric values to be 0.
