### PR TITLE
fix(perf): set max queued metric conf required

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,7 +77,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
-                            ->integerNode('max_queued_metrics')->min(1)->defaultValue(1000)->end()
+                            ->integerNode('max_queued_metrics')->isRequired()->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,7 +77,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
-                            ->integerNode('max_queued_metrics')->min(1)->end()
+                            ->integerNode('max_queued_metrics')->min(1)->defaultValue(1000)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -74,12 +74,13 @@ m6web_statsd_prometheus:
             port: 1236
     clients:
         default_client: #this is the root key / client name.
-            max_queued_metrics: 10 #optional
+            max_queued_metrics: 10
             server: 'default_server'
         client1: #this is the root key / client name.
+            max_queued_metrics: 100
             server: 'server1'
         client2: #this is the root key / client name.
-            max_queued_metrics: 10000 #optional
+            max_queued_metrics: 10000
             server: 'server2'        
 ```
 
@@ -93,10 +94,11 @@ You can name the client key in camelCase or snake_case.
 
 Name of the server you want to use for that client.
 
-* `max_queued_metrics`: int (OPTIONAL)
+* `max_queued_metrics`: int
 
 This is the limit of metrics we can queue before sending them to the UDP server.
-There is no limit by default.
+Depending on your script, accumulate too many metric can cause memory leak issues. 
+We recommend you to set a value between 3000 and 5000 (you can adjust according to your infrastructure).
 
 * `groups` : array
 

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -97,8 +97,8 @@ Name of the server you want to use for that client.
 * `max_queued_metrics`: int
 
 This is the limit of metrics we can queue before sending them to the UDP server.
-Depending on your script, accumulate too many metric can cause memory leak issues. 
-We recommend you to set a value between 3000 and 5000 (you can adjust according to your infrastructure).
+Depending on your script, accumulate too many metrics can cause memory leak issues. 
+We recommend you to set a value between 500 and 1000, and test it to insure that it works with your infrastructure.
 
 * `groups` : array
 

--- a/Tests/DependencyInjection/M6WebStatsdPrometheusExtensionTest.php
+++ b/Tests/DependencyInjection/M6WebStatsdPrometheusExtensionTest.php
@@ -134,6 +134,7 @@ class M6WebStatsdPrometheusExtensionTest extends TestCase
                     'clients' => [
                         'default' => [
                             'server' => 'default',
+                            'max_queued_metrics' => 100,
                             'groups' => [
                                 'groupA' => [
                                     'tags' => [
@@ -199,6 +200,7 @@ class M6WebStatsdPrometheusExtensionTest extends TestCase
                 [
                     'default' => [
                         'server' => 'default',
+                        'max_queued_metrics' => 100,
                         'groups' => [
                             'groupA' => [
                                 'tags' => [


### PR DESCRIPTION
## Why?
<!-- Explain why you've done it like this -->

We have perf and memory issues when a lot of metrics are queued.

## How?
<!-- Explain how you've done it -->

I suggests to set the max queued metric value required and add in the doc an advice for the value.
