### PR TITLE
fix(tagValues): empty request after kernel terminate

### DIFF
--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -154,6 +154,14 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
                 'priority' => -100,
             ]
         );
+        $eventListenerDefinition->addTag(
+            'kernel.event_listener',
+            [
+                'event' => KernelEvents::RESPONSE,
+                'method' => 'onKernelResponse',
+                'priority' => -100,
+            ]
+        );
         if ($this->isSymfonyConsoleComponentLoaded()) {
             // Define event listener on console terminate
             $eventListenerDefinition->addTag(
@@ -199,7 +207,7 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
     {
         return (new Definition(EventListener::class))
             ->setPublic(true)
-            ->addMethodCall('setMetricHandler', [
+            ->setArguments([
                 $this->getMetricHandlerDefinition($clientName, $serverName),
             ]);
     }
@@ -214,8 +222,7 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
             // We use it only for tags right now. That enables us to use complicated tag names
             // such as '@=container.get('kernel')'
             // See the documentation for further help
-            ->addMethodCall('setContainer', [new Reference('service_container')])
-            ->addMethodCall('setMasterRequestFromRequestStack', [new Reference('request_stack')]);
+            ->addMethodCall('setContainer', [new Reference('service_container')]);
     }
 
     protected function getMetricUdpClientDefinition(string $clientName, string $serverName): Definition

--- a/Listener/ConsoleEventsSubscriber.php
+++ b/Listener/ConsoleEventsSubscriber.php
@@ -14,9 +14,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ConsoleEventsSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     protected $eventDispatcher = null;
 
     /**

--- a/Metric/MetricHandler.php
+++ b/Metric/MetricHandler.php
@@ -6,7 +6,6 @@ use M6Web\Bundle\StatsdPrometheusBundle\Client\ClientInterface;
 use M6Web\Bundle\StatsdPrometheusBundle\Exception\MetricException;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class MetricHandler
 {
@@ -97,11 +96,9 @@ class MetricHandler
         $this->container = $container;
     }
 
-    public function setMasterRequestFromRequestStack(RequestStack $requestStack): void
+    public function setRequest(Request $request)
     {
-        //We only need the master request in order to keep all the original request headers
-        //This will be used to resolve advanced configuration tags.
-        $this->request = $requestStack->getMasterRequest();
+        $this->request = $request;
     }
 
     public function setMetricsQueue(\SplQueue $queue): void

--- a/Tests/Listener/EventListenerTest.php
+++ b/Tests/Listener/EventListenerTest.php
@@ -199,7 +199,6 @@ class EventListenerTest extends TestCase
 
     private function getEventListenerObject($metricHandler): EventListener
     {
-        return (new EventListener())
-            ->setMetricHandler($metricHandler);
+        return new EventListener($metricHandler);
     }
 }


### PR DESCRIPTION
## Why?
In SF 4.4 with the debug disabled, we don't have the request anymore after the kernel terminate event.

## How?
Set the request to metric handler on kernel response
