### PR TITLE
feat(dispatch_events): allow to not dispatch internal events

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,8 @@
 
 namespace M6Web\Bundle\StatsdPrometheusBundle\DependencyInjection;
 
+use M6Web\Bundle\StatsdPrometheusBundle\Event\Kernel\KernelExceptionMonitoringEvent;
+use M6Web\Bundle\StatsdPrometheusBundle\Event\Kernel\KernelTerminateMonitoringEvent;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -17,6 +19,7 @@ class Configuration implements ConfigurationInterface
         $this->addServersSection($rootNode);
         $this->addClientsSection($rootNode);
         $this->addTagsSection($rootNode);
+        $this->addDispatchedEventsSection($rootNode);
         $this->addDefaultEventSection($rootNode);
 
         return $treeBuilder;
@@ -94,6 +97,53 @@ class Configuration implements ConfigurationInterface
                 ->end();
     }
 
+    private function addDispatchedEventsSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('dispatched_events')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('http')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enable')
+                                    ->defaultValue(true)
+                                ->end()
+                                ->arrayNode(KernelTerminateMonitoringEvent::class)
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->arrayNode('dispatch_except_for_routes')
+                                            ->prototype('scalar')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode(KernelExceptionMonitoringEvent::class)
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->arrayNode('dispatch_except_for_routes')
+                                            ->prototype('scalar')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('console')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enable')
+                                    ->defaultValue(true)
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @TODO: delete these unused "base_collectors" and "console_events" root keys in the next major release
+     */
     private function addDefaultEventSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -271,6 +271,34 @@ See  Configure the tags](#6-configure-the-tags)
  
 > :information_source: For further help, have a look at the [Examples](usage-and-examples.md) section.
 
+
+Configure the dispatched events
+------
+
+By default, this bundle will dispatch useful monitoring events (see what [KernelTerminateMonitoringEvent](Event/Kernel/KernelTerminateMonitoringEvent.php) contains for example), 
+here is how you can customize the bundle dispatched events:
+
+```yaml
+m6web_statsd_prometheus:
+    dispatched_events:
+        http:
+            enable: false # true by default, use false if you don't want the bundle to dispatch KernelTerminateMonitoringEvent and KernelExceptionMonitoringEvent events
+
+            # customize KernelTerminateMonitoringEvent dispatch rules
+            M6Web\Bundle\StatsdPrometheusBundle\Event\Kernel\KernelTerminateMonitoringEvent:
+                # won't dispatch KernelTerminateMonitoringEvent if the "_route" attribute is "my_route_attribute_name"
+                dispatch_except_for_routes:
+                    - my_route_attribute_name
+
+            # customize KernelExceptionMonitoringEvent dispatch rules
+            M6Web\Bundle\StatsdPrometheusBundle\Event\Kernel\KernelExceptionMonitoringEvent:
+                # won't dispatch KernelExceptionMonitoringEvent if the "_route" attribute is "my_route_attribute_name"
+                dispatch_except_for_routes:
+                    - my_route_attribute_name
+
+        console:
+            enable: false # true by default, use false if you don't want the bundle to dispatch ConsoleCommandMonitoringEvent events
+```
  
 Configure the tags
 ------

--- a/Doc/configuration.md
+++ b/Doc/configuration.md
@@ -276,13 +276,13 @@ Configure the dispatched events
 ------
 
 By default, this bundle will dispatch useful monitoring events (see what [KernelTerminateMonitoringEvent](Event/Kernel/KernelTerminateMonitoringEvent.php) contains for example), 
-here is how you can customize the bundle dispatched events:
+here is how you can customize this behaviour:
 
 ```yaml
 m6web_statsd_prometheus:
     dispatched_events:
         http:
-            enable: false # true by default, use false if you don't want the bundle to dispatch KernelTerminateMonitoringEvent and KernelExceptionMonitoringEvent events
+            enable: true # use false if you don't want the bundle to dispatch http monitoring events at all
 
             # customize KernelTerminateMonitoringEvent dispatch rules
             M6Web\Bundle\StatsdPrometheusBundle\Event\Kernel\KernelTerminateMonitoringEvent:
@@ -297,7 +297,7 @@ m6web_statsd_prometheus:
                     - my_route_attribute_name
 
         console:
-            enable: false # true by default, use false if you don't want the bundle to dispatch ConsoleCommandMonitoringEvent events
+            enable: true # use false if you don't want the bundle to dispatch console monitoring events at all
 ```
  
 Configure the tags

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,7 @@ endef
 
 # BUILD
 .PHONY: build
-build: install quality test sf-security-checker
-
-# BUILD CI
-.PHONY: build-ci
-build-ci: install quality test sf-security-checker
+build: install test quality sf-security-checker
 
 # INSTALL
 .PHONY: install
@@ -44,7 +40,6 @@ clean-bin:
 .PHONY: clean-composer
 clean-composer:
 	$(call printSection,CLEAN-COMPOSER)
-	rm -rf ${SOURCE_DIR}/composer
 	rm -f ${SOURCE_DIR}/composer.install.log
 	rm -f ${SOURCE_DIR}/composer.lock
 
@@ -78,8 +73,10 @@ phpunit:
 	$(call printSection,PHPUNIT)
 	${BIN_DIR}/simple-phpunit
 
+vendor/bin/.phpunit: phpunit
+
 .PHONY: phpstan
-phpstan:
+phpstan: vendor/bin/.phpunit
 	${BIN_DIR}/phpstan.phar analyse
 
 # QUALITY


### PR DESCRIPTION
## Why?
<!-- Explain why you've done it like this -->
- users of this bundle may just want to dispatch some custom events of their choice
  => we should allow users to not dispatch this bundle events, if they don't want to

## How?
<!-- Explain how you've done it -->
- add optional configuration keys to be able to disable bundle events dispatching

## Bonus
- fix `make build` (and remove unused `make build-ci`)
  => simple-phpunit must run before phpstan in order to have phpunit vendor file installed

## Next release: 7.1.0