### PR TITLE
fix(php): Nullable parameter

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -5,6 +5,7 @@ $config = new M6Web\CS\Config\Php71;
 $config->getFinder()
     ->in([
         __DIR__
-    ]);
+    ])
+    ->exclude('Tests/Symfony/');
 
 return $config;

--- a/Client/Server.php
+++ b/Client/Server.php
@@ -18,9 +18,6 @@ class Server implements ServerInterface
     /**
      * Server constructor.
      *
-     * @param string $serverName
-     * @param array  $serverConfig
-     *
      * @throws ServerException
      */
     public function __construct(string $serverName, array $serverConfig)
@@ -34,11 +31,6 @@ class Server implements ServerInterface
 
     /**
      * Init the servers defined in the app configuration
-     *
-     * @param string $serverName
-     * @param array  $serverConfig
-     *
-     * @return bool
      *
      * @throws ServerException
      */

--- a/Client/UdpClient.php
+++ b/Client/UdpClient.php
@@ -21,8 +21,6 @@ class UdpClient implements ClientInterface
 
     /**
      * Split metrics to send them group by group
-     *
-     * @param array $lines
      */
     public function sendLines(array $lines): void
     {

--- a/DependencyInjection/M6WebStatsdPrometheusExtension.php
+++ b/DependencyInjection/M6WebStatsdPrometheusExtension.php
@@ -120,10 +120,6 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
 
     /**
      * Add the "kernel event listener" tag on the given event listener service definition
-     *
-     * @param Definition $eventListenerDefinition
-     * @param array      $groupConfig
-     * @param array      $tagsConfig
      */
     protected function addEventListenerTagsOnServiceDefinition(Definition $eventListenerDefinition, array $groupConfig, array $tagsConfig): void
     {
@@ -231,11 +227,7 @@ class M6WebStatsdPrometheusExtension extends ConfigurableExtension
     {
         // No server found.
         if (!\array_key_exists($serverName, $this->servers)) {
-            throw new InvalidConfigurationException(sprintf(
-                'M6WebStatsd client %s used server %s which is not defined in the servers section',
-                $clientName,
-                $serverName
-            ));
+            throw new InvalidConfigurationException(sprintf('M6WebStatsd client %s used server %s which is not defined in the servers section', $clientName, $serverName));
         }
         // Matched server configurations.
         return new Definition(Server::class, [

--- a/Event/ConsoleMonitoringEvent.php
+++ b/Event/ConsoleMonitoringEvent.php
@@ -11,7 +11,7 @@ class ConsoleMonitoringEvent extends MonitoringEvent
     const ERROR = 'statsdprometheus.console.error';
     const EXCEPTION = 'statsdprometheus.console.exception';
 
-    public static function createFromConsoleEvent(ConsoleEvent $event, int $startTime = 0)
+    public static function createFromConsoleEvent(ConsoleEvent $event, ?int $startTime = 0)
     {
         $executionTime = !is_null($startTime) ? microtime(true) - $startTime : null;
 

--- a/Listener/ConsoleListener.php
+++ b/Listener/ConsoleListener.php
@@ -9,9 +9,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ConsoleListener
 {
-    /**
-     * @var EventDispatcherInterface
-     */
+    /** @var EventDispatcherInterface */
     protected $eventDispatcher = null;
 
     /**

--- a/Listener/ConsoleListener.php
+++ b/Listener/ConsoleListener.php
@@ -17,7 +17,7 @@ class ConsoleListener
     /**
      * Time when command started
      *
-     * @var float
+     * @var ?float
      */
     protected $startTime = null;
 

--- a/Metric/Metric.php
+++ b/Metric/Metric.php
@@ -51,7 +51,6 @@ class Metric implements MetricInterface
      * Metric constructor.
      *
      * @param Event|mixed $event
-     * @param array       $metricConfig
      */
     public function __construct($event, array $metricConfig = [])
     {
@@ -102,10 +101,7 @@ class Metric implements MetricInterface
         }
         if (empty($this->paramValue)) {
             //The param value is required for every type, except for increment which is handled above.
-            throw new MetricException(
-                \sprintf('The configuration of the event metric "%s" must define the "param_value" option.',
-                    \get_class($this->event))
-            );
+            throw new MetricException(\sprintf('The configuration of the event metric "%s" must define the "param_value" option.', \get_class($this->event)));
         }
         if ($this->event instanceof MonitoringEventInterface) {
             // Using the valid event type, values are now in parameters
@@ -113,10 +109,7 @@ class Metric implements MetricInterface
         }
         if (!\method_exists($this->event, $this->paramValue)) {
             // Legacy compatibility
-            throw new MetricException(
-                \sprintf('The event class "%s" must have a "%s" method or parameters in order to measure value.',
-                    \get_class($this->event), $this->paramValue)
-            );
+            throw new MetricException(\sprintf('The event class "%s" must have a "%s" method or parameters in order to measure value.', \get_class($this->event), $this->paramValue));
         }
 
         return $this->correctValue(\call_user_func([$this->event, $this->paramValue]));

--- a/Metric/MetricInterface.php
+++ b/Metric/MetricInterface.php
@@ -26,8 +26,6 @@ interface MetricInterface
      *                         ['resolver1' => $resolver1]
      *                         Used to inject services in tag names:
      *                         format: '@=my_service.myFunction()'
-     *
-     * @return array
      */
     public function getResolvedTags(array $resolvers): array;
 }

--- a/Tests/Metric/MetricTest.php
+++ b/Tests/Metric/MetricTest.php
@@ -453,7 +453,7 @@ class MetricTest extends TestCase
             ],
         ];
 
-        yield 'parameters-missing-from-MonitoringEventInterface' => [
+        yield 'parameters-missing-from-CustomEvent' => [
             $customEvent,
             [
                 'type' => 'increment',

--- a/Tests/Symfony/KernelForTest.php
+++ b/Tests/Symfony/KernelForTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class KernelForTest extends Kernel
+{
+    public function getBundleMap()
+    {
+        return $this->bundleMap;
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+    }
+
+    public function isBooted()
+    {
+        return $this->booted;
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
+    },
+    "autoload-dev": {
+        "files": [
+            "Tests/Symfony/KernelForTest.php"
+        ]
     }
 }


### PR DESCRIPTION
## Why?
If something wrong happen before the beginning of a command, the `startTime` is `null` and it causes a typing issue:
```
Type error: Argument 2 passed to M6Web\Bundle\StatsdPrometheusBundle\Event\ConsoleMonitoringEvent::createFromConsoleEvent() must be of the type int, null given, called in …/vendor/m6web/statsd-prometheus-bundle/Listener/ConsoleListener.php on line 52  
```

## How?
The method `createFromConsoleEvent` should accept `null` value, it's already handled in the code, and `master` branch accept it.

⚠️ First commit contains expected fix, others are here to fix tests 😕 

## Notes
* It's a fix for `v2.x` branch
* On the road for `v2.0.5`
